### PR TITLE
security: 旅行予約・お気に入りルートに認証ミドルウェアを追加

### DIFF
--- a/laravel_project/routes/web.php
+++ b/laravel_project/routes/web.php
@@ -81,14 +81,14 @@ Route::get('/travel/accommodations/{id}', [TravelController::class, 'show'])->na
 Route::get('/travel/accommodations/{id}/plans', [TravelController::class, 'searchPlans'])->name('travel.plans');
 Route::get('/travel/accommodations/{id}/reviews', [TravelController::class, 'reviews'])->name('travel.reviews');
 
-// 予約フロー
-Route::get('/travel/booking/{plan}', [TravelController::class, 'booking'])->name('travel.booking');
-Route::post('/travel/booking/confirm', [TravelController::class, 'confirmBooking'])->name('travel.booking.confirm');
-Route::post('/travel/booking/complete', [TravelController::class, 'completeBooking'])->name('travel.booking.complete');
-
-// お気に入り
-Route::post('/travel/favorites', [TravelController::class, 'addFavorite'])->name('travel.favorites.add');
-Route::delete('/travel/favorites/{accommodation}', [TravelController::class, 'removeFavorite'])->name('travel.favorites.remove');
+// 予約フロー・お気に入り (認証必須)
+Route::middleware('auth')->group(function () {
+    Route::get('/travel/booking/{plan}', [TravelController::class, 'booking'])->name('travel.booking');
+    Route::post('/travel/booking/confirm', [TravelController::class, 'confirmBooking'])->name('travel.booking.confirm');
+    Route::post('/travel/booking/complete', [TravelController::class, 'completeBooking'])->name('travel.booking.complete');
+    Route::post('/travel/favorites', [TravelController::class, 'addFavorite'])->name('travel.favorites.add');
+    Route::delete('/travel/favorites/{accommodation}', [TravelController::class, 'removeFavorite'])->name('travel.favorites.remove');
+});
 
 // エリアAPI
 Route::get('/travel/areas', [TravelController::class, 'areas'])->name('travel.areas');


### PR DESCRIPTION
## 概要

旅行予約フローとお気に入り操作のエンドポイントに `auth` ミドルウェアを適用します。

## 脆弱性

- 未認証ユーザーが `/travel/booking/complete` に POST することで他人の名前・メールで予約が作成できた
- お気に入り追加/削除も未認証で呼び出せたが、コントローラー側の手動チェックのみに依存していた

## 修正内容

`routes/web.php` の旅行予約・お気に入りルートを `Route::middleware('auth')` グループに移動:
- `GET /travel/booking/{plan}`
- `POST /travel/booking/confirm`
- `POST /travel/booking/complete`
- `POST /travel/favorites`
- `DELETE /travel/favorites/{accommodation}`

## テスト計画
- [ ] 未認証で `POST /travel/booking/complete` → ログインページにリダイレクト
- [ ] 認証済みで同エンドポイント → 正常に予約完了

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_