### PR TITLE
security: 選挙システムの書き込みエンドポイントに認証ミドルウェアを追加

### DIFF
--- a/laravel_project/routes/web.php
+++ b/laravel_project/routes/web.php
@@ -113,40 +113,28 @@ Route::get('/api/events/search', [EventController::class, 'apiSearch'])->name('e
 
 // ===== 選挙分析システム =====
 
-// ダッシュボード
+// 閲覧系 (公開)
 Route::get('/elections/dashboard', [ElectionController::class, 'dashboard'])->name('elections.dashboard');
-
-// 選挙関連
 Route::get('/elections', [ElectionController::class, 'index'])->name('elections.index');
-Route::post('/elections', [ElectionController::class, 'store'])->name('elections.store');
 Route::get('/elections/{election}', [ElectionController::class, 'show'])->name('elections.show');
-
-// 議席予測
-Route::post('/elections/{election}/predict', [ElectionController::class, 'predict'])->name('elections.predict');
 Route::get('/elections/{election}/predictions', [ElectionController::class, 'getPredictions'])->name('elections.predictions');
 Route::get('/elections/{election}/validate-accuracy', [ElectionController::class, 'validateAccuracy'])->name('elections.validate-accuracy');
-
-// 選挙比較
 Route::get('/elections-compare', [ElectionController::class, 'compare'])->name('elections.compare');
-
-// 選挙結果登録
-Route::post('/elections/{election}/results', [ElectionController::class, 'storeResult'])->name('elections.results.store');
-
-// 世論調査データ
 Route::get('/poll-data', [ElectionController::class, 'pollData'])->name('poll-data.index');
-Route::post('/poll-data', [ElectionController::class, 'storePollData'])->name('poll-data.store');
-
-// 政党関連
 Route::get('/parties', [ElectionController::class, 'parties'])->name('parties.index');
-Route::post('/parties', [ElectionController::class, 'storeParty'])->name('parties.store');
 Route::get('/parties/{party}/trend', [ElectionController::class, 'partyTrend'])->name('parties.trend');
-
-// 選挙区関連
 Route::get('/election-districts', [ElectionController::class, 'districts'])->name('districts.index');
-
-// インポート・エクスポート
-Route::post('/elections/import-csv', [ElectionController::class, 'importCsv'])->name('elections.import-csv');
 Route::get('/elections/{election}/export', [ElectionController::class, 'exportReport'])->name('elections.export');
+
+// 書き込み系 (認証必須)
+Route::middleware('auth')->group(function () {
+    Route::post('/elections', [ElectionController::class, 'store'])->name('elections.store');
+    Route::post('/elections/{election}/predict', [ElectionController::class, 'predict'])->name('elections.predict');
+    Route::post('/elections/{election}/results', [ElectionController::class, 'storeResult'])->name('elections.results.store');
+    Route::post('/poll-data', [ElectionController::class, 'storePollData'])->name('poll-data.store');
+    Route::post('/parties', [ElectionController::class, 'storeParty'])->name('parties.store');
+    Route::post('/elections/import-csv', [ElectionController::class, 'importCsv'])->name('elections.import-csv');
+});
 
 // ===== テスト用ルート (local環境のみ) =====
 if (!app()->environment('local', 'testing')) {


### PR DESCRIPTION
## 概要

選挙分析システムのデータ変更エンドポイントを認証必須にします。

## 脆弱性

以下の POST エンドポイントが未認証でアクセス可能だった:
- `POST /elections` - 選挙データ登録
- `POST /elections/{election}/predict` - 議席予測実行
- `POST /elections/{election}/results` - 選挙結果登録
- `POST /poll-data` - 世論調査データ登録
- `POST /parties` - 政党登録
- `POST /elections/import-csv` - CSVインポート（特に危険）

## 修正内容

- 閲覧系 GET ルートは公開アクセスを維持
- データ変更を伴う POST ルートを `Route::middleware('auth')` グループに移動

## テスト計画
- [ ] 未認証で `POST /elections` → ログインページにリダイレクト
- [ ] 未認証で `POST /elections/import-csv` → ログインページにリダイレクト
- [ ] 認証済みで同エンドポイント → 正常動作

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_