### PR TITLE
security: ElectionControllerの入力バリデーション・CSVサイズ制限を追加

### DIFF
--- a/laravel_project/app/Http/Controllers/ElectionController.php
+++ b/laravel_project/app/Http/Controllers/ElectionController.php
@@ -26,8 +26,13 @@ class ElectionController extends Controller
      */
     public function dashboard(Request $request)
     {
-        $fromYear = $request->input('from_year', 2010);
-        $toYear = $request->input('to_year', 2026);
+        $request->validate([
+            'from_year' => 'nullable|integer|min:1900|max:2100',
+            'to_year'   => 'nullable|integer|min:1900|max:2100|gte:from_year',
+        ]);
+
+        $fromYear = (int) $request->input('from_year', 2010);
+        $toYear   = (int) $request->input('to_year', 2026);
 
         // 衆議院選挙一覧
         $hrElections = Election::houseOfRepresentatives()
@@ -408,8 +413,8 @@ class ElectionController extends Controller
     public function importCsv(Request $request): JsonResponse
     {
         $request->validate([
-            'file' => 'required|file|mimes:csv,txt',
-            'type' => 'required|in:election,poll',
+            'file'          => 'required|file|mimes:csv,txt|max:10240',
+            'type'          => 'required|in:election,poll',
             'election_type' => 'required_if:type,election|in:house_of_representatives,house_of_councillors',
         ]);
 


### PR DESCRIPTION
## 概要

ElectionController の入力バリデーション不足と CSV ファイルサイズ制限の欠如を修正します。

## 脆弱性

### 1. ダッシュボードの年度パラメータ未検証
```php
$fromYear = $request->input('from_year', 2010); // 無検証
$toYear = $request->input('to_year', 2026);
Carbon::create($fromYear, 1, 1); // 不正な値でクラッシュ
```
`?from_year=99999999` など不正値で `Carbon::create` が例外を投げる。

### 2. CSV インポートにサイズ制限なし
認証されたユーザー（または前の PR でブロックされる前は未認証ユーザー）がギガバイト規模の CSV をアップロードしてサーバーリソースを枯渇させられた。

## 修正内容

- `from_year`/`to_year` を `integer|min:1900|max:2100|gte:from_year` で検証
- CSVファイルに `max:10240`（10MB）制限を追加

## テスト計画
- [ ] `?from_year=abc` → バリデーションエラー
- [ ] `?from_year=9999999` → バリデーションエラー
- [ ] 11MB CSVアップロード → 422 エラー

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_