### PR TITLE
security: EventControllerのキャッシュインジェクション脆弱性を修正

### DIFF
--- a/laravel_project/app/Http/Controllers/EventController.php
+++ b/laravel_project/app/Http/Controllers/EventController.php
@@ -133,16 +133,23 @@ class EventController extends Controller
     public function addFavorite(Request $request)
     {
         $request->validate([
-            'event_id' => 'required|string',
-            'event_data' => 'required|array',
+            'event_id' => 'required|string|max:100',
         ]);
+
+        $eventId = $request->input('event_id');
+
+        // サーバー側でイベントデータを取得し、クライアント供給データは使用しない
+        $event = $this->eventService->findById($eventId);
+        if (!$event) {
+            return response()->json(['success' => false, 'message' => 'イベントが見つかりません'], 404);
+        }
 
         $userId = auth()->id() ?? session()->getId();
         $favorites = Cache::get("event_favorites_{$userId}", []);
 
-        $favorites[$request->event_id] = $request->event_data;
+        $favorites[$eventId] = $event;
 
-        Cache::put("event_favorites_{$userId}", $favorites, 86400 * 30); // 30日間保存
+        Cache::put("event_favorites_{$userId}", $favorites, 86400 * 30);
 
         return response()->json(['success' => true, 'message' => 'お気に入りに追加しました']);
     }

--- a/laravel_project/app/Services/EventSearchService.php
+++ b/laravel_project/app/Services/EventSearchService.php
@@ -434,6 +434,22 @@ class EventSearchService
     }
 
     /**
+     * IDでイベントを検索（信頼できるサーバー側データソースから取得）
+     */
+    public function findById(string $id): ?array
+    {
+        $sampleRegions = ['東京', '大阪', '京都', '北海道', '沖縄', '福岡', '神奈川', '愛知'];
+        foreach ($sampleRegions as $region) {
+            foreach ($this->searchEvents($region) as $event) {
+                if (($event['id'] ?? null) === $id) {
+                    return $event;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
      * 今月の注目イベントを取得
      */
     public function getFeaturedEvents(): array


### PR DESCRIPTION
## 概要

EventController::addFavorite でクライアント供給の `event_data` をそのままキャッシュに保存していたキャッシュインジェクション脆弱性を修正します。

## 脆弱性

```php
// 修正前: 攻撃者が任意の構造・HTMLを event_data として送信できた
$request->validate([
    'event_id'   => 'required|string',
    'event_data' => 'required|array', // ANY array accepted
]);
$favorites[$request->event_id] = $request->event_data; // 悪意あるデータをキャッシュに保存
Cache::put("event_favorites_{$userId}", $favorites, 86400 * 30);
```

- お気に入り一覧ビューでこのデータが描画されると、格納型 XSS になる
- `<script>` や `onerror` を含むデータをキャッシュに永続化できた

## 修正内容

- `event_data` フィールドを受け付けないよう変更
- `event_id` だけ受け取り、`EventSearchService::findById()` でサーバー側からデータを取得
- `EventSearchService` に `findById(string $id): ?array` メソッドを追加

## テスト計画
- [ ] `event_data` に `<script>alert(1)</script>` を含むリクエスト → 無視される
- [ ] 存在しない `event_id` → 404 JSON レスポンス
- [ ] 正常な `event_id` → お気に入りに追加される

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_