### PR TITLE
security: PaymentControllerのリクエスト汚染修正・per_page上限バリデーション追加

### DIFF
--- a/laravel_project/app/Http/Controllers/PaymentController.php
+++ b/laravel_project/app/Http/Controllers/PaymentController.php
@@ -62,9 +62,10 @@ class PaymentController extends Controller
         try {
             $payment = $this->paymentService->createPayment($validated);
 
-            // 決済処理を実行
-            if ($request->has('process_now') && $request->input('process_now')) {
-                $this->paymentService->processPayment($payment, $request->all());
+            // 決済処理を実行（ホワイトリストのフィールドのみ渡す）
+            if ($request->boolean('process_now')) {
+                $gatewayData = $request->only(['stripe_token', 'payment_method_id', 'card_token']);
+                $this->paymentService->processPayment($payment, $gatewayData);
             }
 
             return redirect()->route('payments.show', $payment)

--- a/laravel_project/app/Http/Controllers/TravelController.php
+++ b/laravel_project/app/Http/Controllers/TravelController.php
@@ -369,7 +369,12 @@ class TravelController extends Controller
      */
     public function reviews(Request $request, int $accommodationId): JsonResponse
     {
-        $perPage = $request->input('per_page', 10);
+        $request->validate([
+            'per_page' => 'nullable|integer|min:1|max:100',
+            'sort'     => 'nullable|in:newest,rating_high,rating_low,helpful',
+        ]);
+
+        $perPage = (int) $request->input('per_page', 10);
         $sort = $request->input('sort', 'newest');
 
         $query = Review::with('customer:id,name')


### PR DESCRIPTION
## 概要

PaymentController の `$request->all()` をゲートウェイに渡す問題と、TravelController の無制限 `per_page` を修正します。

## 脆弱性

### 1. PaymentController - $request->all() を決済ゲートウェイに転送 (MEDIUM)
```php
// 修正前: CSRFトークンや攻撃者追加フィールドも含め全部渡していた
$this->paymentService->processPayment($payment, $request->all());
```
実際の決済ゲートウェイ (Stripe 等) 統合時に、攻撃者が `amount`・`currency` 等を上書きできる。

### 2. TravelController::reviews - per_page 無制限 (MEDIUM)
```php
$perPage = $request->input('per_page', 10); // バリデーションなし
```
`?per_page=1000000` で大量データを一括取得してメモリ枯渇 DoS が可能。

## 修正内容

- `processPayment` に渡すデータを `$request->only([...])` でホワイトリスト化
- `per_page` を `max:100` でバリデーション
- `sort` パラメータもホワイトリスト検証を追加

## テスト計画
- [ ] `?per_page=99999` → バリデーションエラー (422)
- [ ] `?sort=malicious_value` → バリデーションエラー
- [ ] 正常な決済処理が通ること

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_