### PR TITLE
security: Customerモデルの$fillableから財務・GDPR削除フィールドを除外

### DIFF
--- a/laravel_project/app/Models/Customer.php
+++ b/laravel_project/app/Models/Customer.php
@@ -17,12 +17,18 @@ class Customer extends Model
         'email',
         'phone',
         'address',
-        'last_stay_date',
-        'total_stays',
-        'total_spent',
         'privacy_consent',
         'privacy_consent_date',
         'marketing_consent',
+    ];
+
+    // total_stays, total_spent は updateStayHistory() 経由でのみ更新
+    // deletion_requested, deletion_requested_at は requestDeletion() 経由でのみ更新
+    // last_stay_date は内部処理でのみ更新
+    protected $guarded = [
+        'total_stays',
+        'total_spent',
+        'last_stay_date',
         'deletion_requested',
         'deletion_requested_at',
     ];


### PR DESCRIPTION
## 概要

`Customer` モデルの `$fillable` に財務集計フィールドと GDPR 削除フラグが含まれていた問題を修正します。

## 脆弱性

```php
// 修正前: 外部入力で財務データや削除フラグが上書き可能だった
protected $fillable = [
    'total_stays',        // 財務集計 — updateStayHistory() 経由のみ
    'total_spent',        // 財務集計
    'last_stay_date',     // 内部処理のみ
    'deletion_requested', // GDPR削除フラグ — requestDeletion() 経由のみ
    'deletion_requested_at',
];
```

`Customer::create($request->all())` や `$customer->update($data)` が呼ばれる箇所で、これらのフィールドを攻撃者が操作できた。

## 修正内容

- `$fillable` から財務・削除フラグフィールドを削除
- `$guarded` に移動し、明示的な代入のみ許可
- 各フィールドが専用メソッド経由でのみ更新されるべきことをコメントで明記

## テスト計画
- [ ] `Customer::create(['total_stays' => 999])` → `total_stays` が無視される
- [ ] 通常のフォームから `total_spent` を送信 → 更新されない
- [ ] `updateStayHistory()` メソッド経由では正常に更新される

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_