### PR TITLE
security: elections/show.blade.phpのDOM XSS脆弱性を修正

### DIFF
--- a/laravel_project/resources/views/elections/show.blade.php
+++ b/laravel_project/resources/views/elections/show.blade.php
@@ -316,22 +316,36 @@ document.getElementById('validateAccuracy')?.addEventListener('click', function(
     .then(response => response.json())
     .then(data => {
         if (data.status === 'success') {
-            let html = '<table class="table table-sm"><thead><tr>';
-            html += '<th>政党</th><th>予測</th><th>実績</th><th>誤差</th><th>範囲内</th></tr></thead><tbody>';
+            const container = document.getElementById('accuracyResults');
+            container.innerHTML = '';
+
+            const table = document.createElement('table');
+            table.className = 'table table-sm';
+            table.innerHTML = '<thead><tr><th>政党</th><th>予測</th><th>実績</th><th>誤差</th><th>範囲内</th></tr></thead>';
+            const tbody = document.createElement('tbody');
 
             for (const [party, result] of Object.entries(data.data.validation)) {
-                html += `<tr>
-                    <td>${party}</td>
-                    <td>${result.predicted}</td>
-                    <td>${result.actual}</td>
-                    <td>${result.error}</td>
-                    <td>${result.within_range ? '<span class="badge bg-success">Yes</span>' : '<span class="badge bg-danger">No</span>'}</td>
-                </tr>`;
+                const tr = document.createElement('tr');
+                [party, result.predicted, result.actual, result.error].forEach(val => {
+                    const td = document.createElement('td');
+                    td.textContent = val;
+                    tr.appendChild(td);
+                });
+                const tdBadge = document.createElement('td');
+                const badge = document.createElement('span');
+                badge.className = result.within_range ? 'badge bg-success' : 'badge bg-danger';
+                badge.textContent = result.within_range ? 'Yes' : 'No';
+                tdBadge.appendChild(badge);
+                tr.appendChild(tdBadge);
+                tbody.appendChild(tr);
             }
-            html += '</tbody></table>';
-            html += `<p class="text-muted">平均誤差: ${data.data.average_error}議席</p>`;
+            table.appendChild(tbody);
+            container.appendChild(table);
 
-            document.getElementById('accuracyResults').innerHTML = html;
+            const p = document.createElement('p');
+            p.className = 'text-muted';
+            p.textContent = `平均誤差: ${Number(data.data.average_error)}議席`;
+            container.appendChild(p);
         }
         this.disabled = false;
     });
@@ -344,9 +358,11 @@ document.getElementById('addResultModal')?.addEventListener('show.bs.modal', fun
     .then(response => response.json())
     .then(data => {
         const select = this.querySelector('select[name="district_id"]');
-        select.innerHTML = '<option value="">選択してください</option>';
+        select.innerHTML = '';
+        const defaultOpt = new Option('選択してください', '');
+        select.appendChild(defaultOpt);
         data.data.forEach(district => {
-            select.innerHTML += `<option value="${district.id}">${district.name}</option>`;
+            select.appendChild(new Option(district.name, district.id));
         });
     });
 
@@ -355,9 +371,10 @@ document.getElementById('addResultModal')?.addEventListener('show.bs.modal', fun
     .then(response => response.json())
     .then(data => {
         const select = this.querySelector('select[name="party_id"]');
-        select.innerHTML = '<option value="">選択してください</option>';
+        select.innerHTML = '';
+        select.appendChild(new Option('選択してください', ''));
         data.data.forEach(party => {
-            select.innerHTML += `<option value="${party.id}">${party.name}</option>`;
+            select.appendChild(new Option(party.name, party.id));
         });
     });
 });


### PR DESCRIPTION
## 概要

`elections/show.blade.php` で API レスポンスのデータを `innerHTML` で描画していた DOM XSS 脆弱性を修正します。

## 脆弱性

```javascript
// 修正前: 政党名・選挙区名をそのまま innerHTML に挿入
html += `<td>${party}</td>`; // ← party に <script> が含まれると実行される
document.getElementById('accuracyResults').innerHTML = html;

// select option も同様
select.innerHTML += `<option value="${district.id}">${district.name}</option>`;
```

選挙システムの書き込み権限のあるユーザーが政党名に ``'&lt;img src=x onerror=alert(document.cookie)&gt;'`` を登録すると、精度検証パネルを開いたすべてのユーザーのブラウザでスクリプトが実行される（格納型 XSS）。

## 修正内容

| 箇所 | 修正前 | 修正後 |
|------|--------|--------|
| 精度テーブル行 | テンプレートリテラル + innerHTML | `createElement` + `textContent` |
| 選挙区 select | `innerHTML +=` | `new Option(name, id)` |
| 政党 select | `innerHTML +=` | `new Option(name, id)` |

`textContent` と `new Option()` は自動的に HTML エスケープを行うため XSS を防止します。

## テスト計画
- [ ] 政党名に `<script>alert(1)</script>` を登録 → 精度パネルにテキストとして表示
- [ ] 選挙区名に `<img onerror=...>` を設定 → テキストとして表示
- [ ] 正常なデータでテーブル・セレクトが正しく描画される

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_