### PR TITLE
security: ReservationControllerのステータス値修正・金額直接入力を廃止

### DIFF
--- a/laravel_project/app/Http/Controllers/ReservationController.php
+++ b/laravel_project/app/Http/Controllers/ReservationController.php
@@ -25,14 +25,19 @@ class ReservationController extends Controller
     public function store(Request $request)
     {
         $validated = $request->validate([
-            'customer_id' => 'required|exists:customers,id',
-            'room_id' => 'required|exists:rooms,id',
-            'check_in_date' => 'required|date|after_or_equal:today',
+            'customer_id'    => 'required|exists:customers,id',
+            'room_id'        => 'required|exists:rooms,id',
+            'check_in_date'  => 'required|date|after_or_equal:today',
             'check_out_date' => 'required|date|after:check_in_date',
-            'status' => 'required|in:pending,confirmed,cancelled,completed',
-            'total_amount' => 'required|numeric|min:0',
-            'notes' => 'nullable|string',
+            // モデルの定数に合わせた値のみ許可 (total_amountはサービスが算出)
+            'status'         => 'required|in:provisional,confirmed,cancelled',
+            'notes'          => 'nullable|string|max:2000',
         ]);
+
+        $room = \App\Models\Room::findOrFail($validated['room_id']);
+        $nights = \Carbon\Carbon::parse($validated['check_in_date'])
+            ->diffInDays(\Carbon\Carbon::parse($validated['check_out_date']));
+        $validated['total_amount'] = $room->price_per_night * $nights;
 
         Reservation::create($validated);
 
@@ -56,14 +61,19 @@ class ReservationController extends Controller
     public function update(Request $request, Reservation $reservation)
     {
         $validated = $request->validate([
-            'customer_id' => 'required|exists:customers,id',
-            'room_id' => 'required|exists:rooms,id',
-            'check_in_date' => 'required|date',
+            'customer_id'    => 'required|exists:customers,id',
+            'room_id'        => 'required|exists:rooms,id',
+            'check_in_date'  => 'required|date',
             'check_out_date' => 'required|date|after:check_in_date',
-            'status' => 'required|in:pending,confirmed,cancelled,completed',
-            'total_amount' => 'required|numeric|min:0',
-            'notes' => 'nullable|string',
+            // モデル定数に合わせた正しいステータス値 (total_amountは再計算)
+            'status'         => 'required|in:provisional,confirmed,checked_in,checked_out,cancelled,no_show',
+            'notes'          => 'nullable|string|max:2000',
         ]);
+
+        $room = \App\Models\Room::findOrFail($validated['room_id']);
+        $nights = \Carbon\Carbon::parse($validated['check_in_date'])
+            ->diffInDays(\Carbon\Carbon::parse($validated['check_out_date']));
+        $validated['total_amount'] = $room->price_per_night * $nights;
 
         $reservation->update($validated);
 


### PR DESCRIPTION
## 概要

ReservationController のステータスバリデーション不備と `total_amount` の直接入力を修正します。

## 脆弱性

### 1. 不正なステータス値によるステートマシンバイパス (HIGH)
```php
// 修正前: モデル定数と異なる値を許可していた
'status' => 'required|in:pending,confirmed,cancelled,completed',
```
`pending`/`completed` は Reservation モデルに存在しない値。正しい定数は `provisional`/`checked_out`。
攻撃者が `status=completed` を送信すると DB に矛盾したステータスが保存され、キャンセルポリシーや支払い状態の整合性が崩れる。

### 2. total_amount の直接入力 (HIGH)
```php
// 修正前: ユーザーが金額を自由に設定できた
'total_amount' => 'required|numeric|min:0',
Reservation::create($validated);
```
認証済みユーザーが `total_amount=1` などを送信することで、任意の金額で予約を作成・更新できた。

## 修正内容

- `status` の許可値を Reservation モデル定数に合わせて修正
- `total_amount` をリクエストから削除し、`room.price_per_night × 宿泊数` でサーバー側計算

## テスト計画
- [ ] `status=pending` を送信 → バリデーションエラー (422)
- [ ] `total_amount=1` を送信 → 無視され、正しい金額が算出される
- [ ] 正常な予約作成・更新が通ること

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_