### PR TITLE
security: レビュー管理者返信をGate認可で保護・RBACの基盤を追加

### DIFF
--- a/laravel_project/app/Http/Controllers/ReviewController.php
+++ b/laravel_project/app/Http/Controllers/ReviewController.php
@@ -6,6 +6,7 @@ use App\Models\Review;
 use App\Models\Reservation;
 use App\Models\Accommodation;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
 
 class ReviewController extends Controller
@@ -195,6 +196,11 @@ class ReviewController extends Controller
      */
     public function addAdminResponse(Review $review, Request $request)
     {
+        // 施設管理者のみ返信可能。'admin' Gateはis_adminフラグまたは将来のRBACと連動。
+        if (Gate::denies('admin')) {
+            abort(403, '施設管理者のみ返信できます。');
+        }
+
         $validated = $request->validate([
             'admin_response' => 'required|string|max:1000',
         ]);

--- a/laravel_project/app/Providers/AppServiceProvider.php
+++ b/laravel_project/app/Providers/AppServiceProvider.php
@@ -2,23 +2,22 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
-    /**
-     * Register any application services.
-     */
     public function register(): void
     {
         //
     }
 
-    /**
-     * Bootstrap any application services.
-     */
     public function boot(): void
     {
-        //
+        // 管理者ゲート: User モデルに is_admin カラムが追加されたら自動的に機能する。
+        // 現時点では全ユーザーが false になるため、addAdminResponse は管理者のみ利用可能。
+        Gate::define('admin', function ($user) {
+            return (bool) ($user->is_admin ?? false);
+        });
     }
 }


### PR DESCRIPTION
## 概要

`ReviewController::addAdminResponse` が任意の認証済みユーザーから呼び出せた問題を修正し、将来の RBAC に向けた Gate の基盤を追加します。

## 脆弱性

```php
// 修正前: 認証さえされていれば誰でも施設の公式返信を投稿できた
public function addAdminResponse(Review $review, Request $request)
{
    $validated = $request->validate(['admin_response' => 'required|string|max:1000']);
    $review->addAdminResponse($validated['admin_response']); // 権限チェックなし
}
```

宿泊客が自分のレビューに「施設からの公式回答」を偽って書き込める。

## 修正内容

### AppServiceProvider
```php
Gate::define('admin', function ($user) {
    return (bool) ($user->is_admin ?? false);
});
```

### ReviewController::addAdminResponse
```php
if (Gate::denies('admin')) {
    abort(403, '施設管理者のみ返信できます。');
}
```

`User` モデルに `is_admin` カラムを追加するだけで Gate が有効になる設計。

## テスト計画
- [ ] 一般ユーザーで `POST /reviews/{review}/admin-response` → 403
- [ ] `is_admin=true` のユーザーで同エンドポイント → 正常に返信投稿

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_