### PR TITLE
security: APIおよびWebルートにレート制限を追加

### DIFF
--- a/laravel_project/routes/api.php
+++ b/laravel_project/routes/api.php
@@ -3,6 +3,17 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Models\Customer;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Support\Facades\RateLimiter;
+
+// APIレート制限の設定
+RateLimiter::for('api', function (Request $request) {
+    return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
+});
+
+RateLimiter::for('api-write', function (Request $request) {
+    return Limit::perMinute(20)->by($request->user()?->id ?: $request->ip());
+});
 
 /*
 |--------------------------------------------------------------------------

--- a/laravel_project/routes/web.php
+++ b/laravel_project/routes/web.php
@@ -71,82 +71,68 @@ Route::middleware('auth')->group(function () {
 
 // ===== 旅行検索サイト =====
 
-// トップ・検索
-Route::get('/travel', [TravelController::class, 'index'])->name('travel.index');
-Route::get('/travel/search', [TravelController::class, 'search'])->name('travel.search');
-Route::get('/travel/suggest', [TravelController::class, 'suggest'])->name('travel.suggest');
+// 公開検索 (レート制限: 60回/分)
+Route::middleware('throttle:api')->group(function () {
+    Route::get('/travel', [TravelController::class, 'index'])->name('travel.index');
+    Route::get('/travel/search', [TravelController::class, 'search'])->name('travel.search');
+    Route::get('/travel/suggest', [TravelController::class, 'suggest'])->name('travel.suggest');
+    Route::get('/travel/accommodations/{id}', [TravelController::class, 'show'])->name('travel.show');
+    Route::get('/travel/accommodations/{id}/plans', [TravelController::class, 'searchPlans'])->name('travel.plans');
+    Route::get('/travel/accommodations/{id}/reviews', [TravelController::class, 'reviews'])->name('travel.reviews');
+    Route::get('/travel/booking/{plan}', [TravelController::class, 'booking'])->name('travel.booking');
+    Route::get('/travel/areas', [TravelController::class, 'areas'])->name('travel.areas');
+});
 
-// 施設詳細
-Route::get('/travel/accommodations/{id}', [TravelController::class, 'show'])->name('travel.show');
-Route::get('/travel/accommodations/{id}/plans', [TravelController::class, 'searchPlans'])->name('travel.plans');
-Route::get('/travel/accommodations/{id}/reviews', [TravelController::class, 'reviews'])->name('travel.reviews');
-
-// 予約フロー
-Route::get('/travel/booking/{plan}', [TravelController::class, 'booking'])->name('travel.booking');
-Route::post('/travel/booking/confirm', [TravelController::class, 'confirmBooking'])->name('travel.booking.confirm');
-Route::post('/travel/booking/complete', [TravelController::class, 'completeBooking'])->name('travel.booking.complete');
-
-// お気に入り
-Route::post('/travel/favorites', [TravelController::class, 'addFavorite'])->name('travel.favorites.add');
-Route::delete('/travel/favorites/{accommodation}', [TravelController::class, 'removeFavorite'])->name('travel.favorites.remove');
-
-// エリアAPI
-Route::get('/travel/areas', [TravelController::class, 'areas'])->name('travel.areas');
+// 予約フロー・お気に入り (認証必須 + 書き込みレート制限: 20回/分)
+Route::middleware(['auth', 'throttle:api-write'])->group(function () {
+    Route::post('/travel/booking/confirm', [TravelController::class, 'confirmBooking'])->name('travel.booking.confirm');
+    Route::post('/travel/booking/complete', [TravelController::class, 'completeBooking'])->name('travel.booking.complete');
+    Route::post('/travel/favorites', [TravelController::class, 'addFavorite'])->name('travel.favorites.add');
+    Route::delete('/travel/favorites/{accommodation}', [TravelController::class, 'removeFavorite'])->name('travel.favorites.remove');
+});
 
 // ===== イベント検索システム =====
 
-// トップ・検索
-Route::get('/events', [EventController::class, 'index'])->name('events.index');
-Route::get('/events/search', [EventController::class, 'search'])->name('events.search');
-Route::get('/events/calendar', [EventController::class, 'calendar'])->name('events.calendar');
+// 公開読み取り (レート制限: 60回/分)
+Route::middleware('throttle:api')->group(function () {
+    Route::get('/events', [EventController::class, 'index'])->name('events.index');
+    Route::get('/events/search', [EventController::class, 'search'])->name('events.search');
+    Route::get('/events/calendar', [EventController::class, 'calendar'])->name('events.calendar');
+    Route::get('/events/{id}', [EventController::class, 'show'])->name('events.show');
+    Route::get('/events/my/favorites', [EventController::class, 'favorites'])->name('events.favorites');
+    Route::get('/api/events/search', [EventController::class, 'apiSearch'])->name('events.api.search');
+});
 
-// イベント詳細
-Route::get('/events/{id}', [EventController::class, 'show'])->name('events.show');
-
-// お気に入り
-Route::get('/events/my/favorites', [EventController::class, 'favorites'])->name('events.favorites');
-Route::post('/events/favorites', [EventController::class, 'addFavorite'])->name('events.favorites.add');
-Route::delete('/events/favorites/{eventId}', [EventController::class, 'removeFavorite'])->name('events.favorites.remove');
-
-// API
-Route::get('/api/events/search', [EventController::class, 'apiSearch'])->name('events.api.search');
+// お気に入り書き込み (認証必須 + 書き込みレート制限: 20回/分)
+Route::middleware(['auth', 'throttle:api-write'])->group(function () {
+    Route::post('/events/favorites', [EventController::class, 'addFavorite'])->name('events.favorites.add');
+    Route::delete('/events/favorites/{eventId}', [EventController::class, 'removeFavorite'])->name('events.favorites.remove');
+});
 
 // ===== 選挙分析システム =====
 
-// ダッシュボード
+// 公開読み取り
 Route::get('/elections/dashboard', [ElectionController::class, 'dashboard'])->name('elections.dashboard');
-
-// 選挙関連
 Route::get('/elections', [ElectionController::class, 'index'])->name('elections.index');
-Route::post('/elections', [ElectionController::class, 'store'])->name('elections.store');
 Route::get('/elections/{election}', [ElectionController::class, 'show'])->name('elections.show');
-
-// 議席予測
-Route::post('/elections/{election}/predict', [ElectionController::class, 'predict'])->name('elections.predict');
 Route::get('/elections/{election}/predictions', [ElectionController::class, 'getPredictions'])->name('elections.predictions');
 Route::get('/elections/{election}/validate-accuracy', [ElectionController::class, 'validateAccuracy'])->name('elections.validate-accuracy');
-
-// 選挙比較
 Route::get('/elections-compare', [ElectionController::class, 'compare'])->name('elections.compare');
-
-// 選挙結果登録
-Route::post('/elections/{election}/results', [ElectionController::class, 'storeResult'])->name('elections.results.store');
-
-// 世論調査データ
 Route::get('/poll-data', [ElectionController::class, 'pollData'])->name('poll-data.index');
-Route::post('/poll-data', [ElectionController::class, 'storePollData'])->name('poll-data.store');
-
-// 政党関連
 Route::get('/parties', [ElectionController::class, 'parties'])->name('parties.index');
-Route::post('/parties', [ElectionController::class, 'storeParty'])->name('parties.store');
 Route::get('/parties/{party}/trend', [ElectionController::class, 'partyTrend'])->name('parties.trend');
-
-// 選挙区関連
 Route::get('/election-districts', [ElectionController::class, 'districts'])->name('districts.index');
-
-// インポート・エクスポート
-Route::post('/elections/import-csv', [ElectionController::class, 'importCsv'])->name('elections.import-csv');
 Route::get('/elections/{election}/export', [ElectionController::class, 'exportReport'])->name('elections.export');
+
+// 書き込み操作 (認証必須 + 書き込みレート制限: 20回/分)
+Route::middleware(['auth', 'throttle:api-write'])->group(function () {
+    Route::post('/elections', [ElectionController::class, 'store'])->name('elections.store');
+    Route::post('/elections/{election}/predict', [ElectionController::class, 'predict'])->name('elections.predict');
+    Route::post('/elections/{election}/results', [ElectionController::class, 'storeResult'])->name('elections.results.store');
+    Route::post('/poll-data', [ElectionController::class, 'storePollData'])->name('poll-data.store');
+    Route::post('/parties', [ElectionController::class, 'storeParty'])->name('parties.store');
+    Route::post('/elections/import-csv', [ElectionController::class, 'importCsv'])->name('elections.import-csv');
+});
 
 // ===== テスト用ルート (local環境のみ) =====
 if (!app()->environment('local', 'testing')) {


### PR DESCRIPTION
## 概要

APIエンドポイントおよびWebルートにレート制限を追加し、ブルートフォース攻撃・DoS攻撃・スクレイピングを防止します。

## 変更内容

### `routes/api.php`
- `RateLimiter::for('api', 60回/分)` を定義（読み取りAPI用）
- `RateLimiter::for('api-write', 20回/分)` を定義（書き込みAPI用）
- レート制限キーはユーザーID（認証済み）またはIPアドレス（未認証）

### `routes/web.php`
- 旅行検索・施設詳細・イベント検索の**公開ルート**に `throttle:api`（60回/分）を適用
- 予約完了・お気に入り追加削除・イベントお気に入りの**書き込みルート**に `auth + throttle:api-write`（20回/分）を適用
- 選挙データの書き込み操作（`store`, `predict`, `storeResult`, `storePollData`, `storeParty`, `importCsv`）に `auth + throttle:api-write` を適用

## セキュリティ上の効果

| リスク | 対策 |
|--------|------|
| APIブルートフォース | 60回/分の制限で攻撃コスト増大 |
| 予約・決済の連打 | 20回/分の書き込み制限 |
| 選挙データの大量投入 | import-csv 等を認証 + レート制限に変更 |
| スクレイピング | 検索・サジェストAPIに制限を適用 |

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_