### PR TITLE
security: Paymentモデルの機密フィールドをマスアサインメントから除外

### DIFF
--- a/laravel_project/app/Models/Payment.php
+++ b/laravel_project/app/Models/Payment.php
@@ -10,20 +10,25 @@ class Payment extends Model
 {
     use HasFactory;
 
+    // 初回作成時にユーザー入力から受け取る項目のみ
     protected $fillable = [
         'reservation_id',
         'amount',
         'payment_method',
+        'payment_gateway',
+        'notes',
+    ];
+
+    // 決済状態・返金・取引IDはサービス層でのみ設定する
+    protected $guarded = [
         'status',
         'transaction_id',
-        'payment_gateway',
         'payment_details',
         'paid_at',
         'refunded_at',
         'refund_amount',
         'refund_reason',
         'failure_reason',
-        'notes',
     ];
 
     protected $casts = [
@@ -47,11 +52,10 @@ class Payment extends Model
      */
     public function markAsPaid(string $transactionId = null): void
     {
-        $this->update([
-            'status' => 'completed',
-            'paid_at' => now(),
-            'transaction_id' => $transactionId ?? $this->transaction_id,
-        ]);
+        $this->status = 'completed';
+        $this->paid_at = now();
+        $this->transaction_id = $transactionId ?? $this->transaction_id;
+        $this->save();
     }
 
     /**
@@ -59,10 +63,9 @@ class Payment extends Model
      */
     public function markAsFailed(string $reason): void
     {
-        $this->update([
-            'status' => 'failed',
-            'failure_reason' => $reason,
-        ]);
+        $this->status = 'failed';
+        $this->failure_reason = $reason;
+        $this->save();
     }
 
     /**
@@ -70,14 +73,11 @@ class Payment extends Model
      */
     public function refund(float $amount = null, string $reason = null): void
     {
-        $refundAmount = $amount ?? $this->amount;
-
-        $this->update([
-            'status' => 'refunded',
-            'refunded_at' => now(),
-            'refund_amount' => $refundAmount,
-            'refund_reason' => $reason,
-        ]);
+        $this->status = 'refunded';
+        $this->refunded_at = now();
+        $this->refund_amount = $amount ?? $this->amount;
+        $this->refund_reason = $reason;
+        $this->save();
     }
 
     /**


### PR DESCRIPTION
## 概要

Payment モデルの `$fillable` から決済状態・返金情報・取引IDなど機密性の高いフィールドを除外し、マスアサインメントによる不正な決済状態の書き換えを防止します。

## 脆弱性の詳細

以下のフィールドが `$fillable` に含まれており、`Payment::create($request->all())` や `$payment->update($request->all())` 等が呼ばれた場合に、ユーザー入力で直接上書きできました：

| フィールド | リスク |
|-----------|--------|
| `status` | `status=completed` を直接送信して未払いを支払済みに偽装 |
| `transaction_id` | 偽の取引IDを挿入 |
| `paid_at` | 支払日時を偽造 |
| `refunded_at` | 返金日時を偽造 |
| `refund_amount` | 返金額を改ざん |
| `refund_reason` | 返金理由を書き換え |
| `failure_reason` | 失敗理由を書き換え |
| `payment_details` | 決済詳細JSON全体を上書き |

## 修正内容

```php
// $fillable: 初回作成時にユーザー入力で受け取る項目のみ
protected $fillable = [
    'reservation_id', 'amount', 'payment_method', 'payment_gateway', 'notes',
];

// $guarded: サービス層でのみ設定する機密フィールド
protected $guarded = [
    'status', 'transaction_id', 'payment_details',
    'paid_at', 'refunded_at', 'refund_amount', 'refund_reason', 'failure_reason',
];
```

モデル内の `markAsPaid()` / `markAsFailed()` / `refund()` メソッドを `update()` からプロパティ直接代入 + `save()` に変更し、`$guarded` の影響を受けずに内部処理が機能するよう調整しました。

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_