### PR TITLE
security: Reservationモデルの機密フィールドをマスアサインメントから除外

### DIFF
--- a/laravel_project/app/Models/Reservation.php
+++ b/laravel_project/app/Models/Reservation.php
@@ -29,12 +29,20 @@ class Reservation extends Model
         self::STATUS_NO_SHOW => [],
     ];
 
+    // 予約作成時にユーザー入力から受け取る基本項目のみ
     protected $fillable = [
         'customer_id',
         'room_id',
         'number_of_guests',
         'check_in_date',
         'check_out_date',
+        'notes',
+        'created_by_user_id',
+        'updated_by_user_id',
+    ];
+
+    // ステータス・金額・時刻系はサービス層・ステートマシンでのみ設定する
+    protected $guarded = [
         'status',
         'payment_status',
         'actual_check_in_time',
@@ -44,9 +52,6 @@ class Reservation extends Model
         'price_breakdown',
         'cancelled_at',
         'cancellation_reason',
-        'notes',
-        'created_by_user_id',
-        'updated_by_user_id',
     ];
 
     protected $casts = [


### PR DESCRIPTION
## 概要

Reservation モデルの `$fillable` から予約状態・金額・チェックイン/アウト時刻など機密性の高いフィールドを除外し、マスアサインメントによる不正な予約状態の書き換えを防止します。

## 脆弱性の詳細

以下のフィールドが `$fillable` に含まれており、悪意あるリクエストで直接上書きできました：

| フィールド | リスク |
|-----------|--------|
| `status` | `status=checked_out` を直接送信して未チェックアウトを偽装 |
| `payment_status` | 未払いを支払済みに偽装 |
| `total_amount` | 宿泊料金を任意の値に改ざん |
| `actual_check_in_time` / `actual_check_out_time` | チェックイン/アウト時刻を偽造 |
| `applied_discounts` / `price_breakdown` | 割引計算結果を偽造 |
| `cancelled_at` / `cancellation_reason` | キャンセル情報を偽造 |

## 修正内容

```php
// $fillable: 予約作成時にユーザー入力から受け取る基本項目のみ
protected $fillable = [
    'customer_id', 'room_id', 'number_of_guests',
    'check_in_date', 'check_out_date', 'notes',
    'created_by_user_id', 'updated_by_user_id',
];

// $guarded: サービス層・ステートマシンでのみ設定する項目
protected $guarded = [
    'status', 'payment_status',
    'actual_check_in_time', 'actual_check_out_time',
    'total_amount', 'applied_discounts', 'price_breakdown',
    'cancelled_at', 'cancellation_reason',
];
```

## 動作への影響

`changeStatus()` / `checkIn()` / `checkOut()` メソッドは既にプロパティ直接代入（`$this->status = ...`）を使用しているため、`$guarded` の適用後も正常に動作します。

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_