### PR TITLE
security: Travel・EventControllerの入力バリデーションを強化

### DIFF
--- a/laravel_project/app/Http/Controllers/EventController.php
+++ b/laravel_project/app/Http/Controllers/EventController.php
@@ -179,8 +179,13 @@ class EventController extends Controller
      */
     public function calendar(Request $request)
     {
-        $region = $request->get('region', '東京');
-        $month = $request->get('month', date('Y-m'));
+        $validated = $request->validate([
+            'region' => 'nullable|string|max:100',
+            'month'  => 'nullable|date_format:Y-m',
+        ]);
+
+        $region = $validated['region'] ?? '東京';
+        $month = $validated['month'] ?? date('Y-m');
 
         $startDate = $month . '-01';
         $endDate = date('Y-m-t', strtotime($startDate));

--- a/laravel_project/app/Http/Controllers/TravelController.php
+++ b/laravel_project/app/Http/Controllers/TravelController.php
@@ -332,6 +332,8 @@ class TravelController extends Controller
      */
     public function suggest(Request $request): JsonResponse
     {
+        $request->validate(['q' => 'nullable|string|max:200']);
+
         $keyword = $request->input('q', '');
 
         if (mb_strlen($keyword) < 1) {
@@ -348,8 +350,13 @@ class TravelController extends Controller
      */
     public function areas(Request $request): JsonResponse
     {
-        $parentId = $request->input('parent_id');
-        $level = $request->input('level');
+        $request->validate([
+            'parent_id' => 'nullable|integer|exists:areas,id',
+            'level'     => 'nullable|integer|min:1|max:5',
+        ]);
+
+        $parentId = $request->integer('parent_id') ?: null;
+        $level = $request->integer('level') ?: null;
 
         $query = Area::query();
 


### PR DESCRIPTION
## 概要

TravelController と EventController の複数エンドポイントで入力パラメータが未検証のまま使用されていた問題を修正します。

## 脆弱性の詳細

### 1. `TravelController::suggest()` — `q` パラメータに長さ制限なし

```php
// 修正前
$keyword = $request->input('q', '');
// 任意の長さの文字列が検索サービスに渡される
$results = $this->searchService->suggest($keyword);
```

極端に長い文字列を渡すことで検索処理に過大な負荷をかけられました。

### 2. `TravelController::areas()` — `parent_id`・`level` が未検証

```php
// 修正前
$parentId = $request->input('parent_id');  // 任意の値
$level = $request->input('level');          // 任意の値
$query->where('parent_id', $parentId);
$query->where('level', $level);
```

PDO バインディングで SQL インジェクションは防がれますが、存在しないIDや型の異なる値が渡されていました。

### 3. `EventController::calendar()` — `month` が `strtotime()` に直接渡される

```php
// 修正前
$month = $request->get('month', date('Y-m'));  // 未検証
$startDate = $month . '-01';
$endDate = date('Y-m-t', strtotime($startDate));  // 不正な入力で予期しない動作
```

`month` を `date_format:Y-m` で検証せずに `strtotime()` に渡していたため、不正な文字列で予期しない日付になる可能性がありました。

## 修正内容

```php
// suggest()
$request->validate(['q' => 'nullable|string|max:200']);

// areas()
$request->validate([
    'parent_id' => 'nullable|integer|exists:areas,id',
    'level'     => 'nullable|integer|min:1|max:5',
]);
$parentId = $request->integer('parent_id') ?: null;
$level    = $request->integer('level') ?: null;

// calendar()
$validated = $request->validate([
    'region' => 'nullable|string|max:100',
    'month'  => 'nullable|date_format:Y-m',
]);
```

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_