### PR TITLE
security: QRコードダウンロードのHTTPヘッダーインジェクションを修正

### DIFF
--- a/laravel_project/app/Http/Controllers/ProductController.php
+++ b/laravel_project/app/Http/Controllers/ProductController.php
@@ -159,7 +159,8 @@ class ProductController extends Controller
             ->errorCorrection('M')
             ->generate($url);
 
-        $filename = 'qrcode_' . $product->sku . '.png';
+        $safeSku = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $product->sku);
+        $filename = 'qrcode_' . $safeSku . '.png';
 
         return response($png, 200)
             ->header('Content-Type', 'image/png')


### PR DESCRIPTION
## 概要

`ProductController::qrcodeDownload()` が `$product->sku` を `Content-Disposition` ヘッダーの `filename` に直接埋め込んでおり、HTTP ヘッダーインジェクションが可能だった問題を修正します。

## 脆弱性の詳細

```php
// 修正前: SKU を無加工でヘッダー値に使用
$filename = 'qrcode_' . $product->sku . '.png';
return response($png, 200)
    ->header('Content-Disposition', 'attachment; filename="' . $filename . '"');
```

`products.sku` フィールドは `string|max:100` のみで検証されており文字種の制限がありません。管理者が特殊文字を含む SKU（例: `foo"\r\nX-Custom-Header: injected`）を登録した場合、レスポンスヘッダーに任意の内容を注入できました。

## 修正内容

```php
// 修正後: 安全な文字のみ使用してファイル名を構築
$safeSku = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $product->sku);
$filename = 'qrcode_' . $safeSku . '.png';
```

英数字・アンダースコア・ハイフン以外の文字（引用符、改行文字等）を `_` に置換するため、ヘッダー値として安全なファイル名が生成されます。

## 影響範囲

`GET /products/{product}/qrcode/download` エンドポイントのみ。QRコードの SVG 表示 (`/qrcode`) は `Content-Disposition` ヘッダーを使用していないため影響なし。

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_