### PR TITLE
security: ElectionController::partyTrend()の日付パラメータにバリデーションを追加

### DIFF
--- a/laravel_project/app/Http/Controllers/ElectionController.php
+++ b/laravel_project/app/Http/Controllers/ElectionController.php
@@ -271,6 +271,11 @@ class ElectionController extends Controller
      */
     public function partyTrend(Request $request, PoliticalParty $party): JsonResponse
     {
+        $request->validate([
+            'start_date' => 'nullable|date|after_or_equal:1900-01-01',
+            'end_date'   => 'nullable|date|after_or_equal:start_date',
+        ]);
+
         $startDate = Carbon::parse($request->input('start_date', '2010-01-01'));
         $endDate = Carbon::parse($request->input('end_date', now()));
 


### PR DESCRIPTION
## 概要

`ElectionController::partyTrend()` が `start_date` / `end_date` パラメータを検証なしに `Carbon::parse()` に直接渡していた問題を修正します。このエンドポイントは認証不要の公開エンドポイントです。

## 脆弱性の詳細

```php
// 修正前: 未検証の入力を Carbon::parse() に渡す
$startDate = Carbon::parse($request->input('start_date', '2010-01-01'));
$endDate   = Carbon::parse($request->input('end_date', now()));
```

`GET /parties/{party}/trend` は公開ルートであり、任意のユーザーが `start_date=<不正文字列>` を送信できました。`Carbon::parse()` は多くの文字列を受け付けますが、検証なしに外部入力を渡すことは意図しない日付範囲の生成や、将来のコード変更で悪用されるリスクがあります。

## 修正内容

```php
$request->validate([
    'start_date' => 'nullable|date|after_or_equal:1900-01-01',
    'end_date'   => 'nullable|date|after_or_equal:start_date',
]);

$startDate = Carbon::parse($request->input('start_date', '2010-01-01'));
$endDate   = Carbon::parse($request->input('end_date', now()));
```

- `date` ルールで有効な日付形式のみ受け付ける
- `after_or_equal:1900-01-01` で不合理な過去日を拒否
- `after_or_equal:start_date` で終了日が開始日以降であることを保証

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_