### PR TITLE
feat: QR label print page for individual products

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Product;
+use Illuminate\Http\Request;
+use SimpleSoftwareIO\QrCode\Facades\QrCode;
+
+/**
+ * 商品管理コントローラー
+ *
+ * WHY: Controllerは薄く保ち、ビジネスロジックはServiceに委譲
+ */
+class ProductController extends Controller
+{
+    /**
+     * 在庫一覧表示
+     */
+    public function index(Request $request)
+    {
+        $query = Product::query();
+
+        // 検索フィルタ
+        if ($request->filled('search')) {
+            $search = $request->input('search');
+            $query->where(function ($q) use ($search) {
+                $q->where('sku', 'like', "%{$search}%")
+                  ->orWhere('name', 'like', "%{$search}%");
+            });
+        }
+
+        // 在庫アラートフィルタ
+        if ($request->boolean('alert_only')) {
+            $query->belowReorderPoint();
+        }
+
+        // ソート（デフォルト: 在庫が少ない順）
+        $sortBy = $request->input('sort', 'stock_asc');
+        switch ($sortBy) {
+            case 'stock_asc':
+                $query->orderBy('stock_quantity', 'asc');
+                break;
+            case 'stock_desc':
+                $query->orderBy('stock_quantity', 'desc');
+                break;
+            case 'name':
+                $query->orderBy('name', 'asc');
+                break;
+        }
+
+        $products = $query->paginate(20);
+
+        return view('products.index', compact('products'));
+    }
+
+    /**
+     * 商品登録フォーム
+     */
+    public function create()
+    {
+        return view('products.create');
+    }
+
+    /**
+     * 商品登録処理
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'sku' => ['required', 'string', 'max:100', 'unique:products'],
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'stock_quantity' => ['required', 'integer', 'min:0'],
+            'reorder_point' => ['required', 'integer', 'min:0'],
+        ]);
+
+        Product::create($validated);
+
+        return redirect()
+            ->route('products.index')
+            ->with('success', '商品を登録しました');
+    }
+
+    /**
+     * 商品詳細（在庫履歴表示）
+     */
+    public function show(Product $product)
+    {
+        $transactions = $product->stockTransactions()
+            ->latest()
+            ->paginate(50);
+
+        return view('products.show', compact('product', 'transactions'));
+    }
+
+    /**
+     * 商品更新フォーム
+     */
+    public function edit(Product $product)
+    {
+        return view('products.edit', compact('product'));
+    }
+
+    /**
+     * 商品更新処理
+     */
+    public function update(Request $request, Product $product)
+    {
+        $validated = $request->validate([
+            'sku' => ['required', 'string', 'max:100', 'unique:products,sku,' . $product->id],
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'reorder_point' => ['required', 'integer', 'min:0'],
+        ]);
+
+        $product->update($validated);
+
+        return redirect()
+            ->route('products.index')
+            ->with('success', '商品情報を更新しました');
+    }
+
+    /**
+     * 商品削除
+     */
+    public function destroy(Product $product)
+    {
+        $product->delete();
+
+        return redirect()
+            ->route('products.index')
+            ->with('success', '商品を削除しました');
+    }
+
+    /**
+     * QRコード画像を返す（SVG形式）
+     * QRコードにはSKUと商品詳細URLをエンコード
+     */
+    public function qrcode(Product $product)
+    {
+        $url = route('products.show', $product);
+        $svg = QrCode::format('svg')
+            ->size(200)
+            ->errorCorrection('M')
+            ->generate($url);
+
+        return response($svg, 200)
+            ->header('Content-Type', 'image/svg+xml');
+    }
+
+    /**
+     * QRコードをPNGとしてダウンロード
+     */
+    public function qrcodeDownload(Product $product)
+    {
+        $url = route('products.show', $product);
+        $png = QrCode::format('png')
+            ->size(300)
+            ->errorCorrection('M')
+            ->generate($url);
+
+        $filename = 'qrcode_' . $product->sku . '.png';
+
+        return response($png, 200)
+            ->header('Content-Type', 'image/png')
+            ->header('Content-Disposition', 'attachment; filename="' . $filename . '"');
+    }
+
+    public function label(Product $product)
+    {
+        return view('products.qr-label', compact('product'));
+    }
+}

--- a/resources/views/products/qr-label.blade.php
+++ b/resources/views/products/qr-label.blade.php
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>QRラベル - {{ $product->sku }}</title>
+    <style>
+        body { margin: 0; padding: 20px; font-family: sans-serif; background: #fff; }
+        .label {
+            display: inline-block;
+            border: 2px solid #333;
+            border-radius: 8px;
+            padding: 16px 20px;
+            text-align: center;
+            min-width: 220px;
+        }
+        .label img { display: block; margin: 0 auto; }
+        .label .name { font-size: 14px; font-weight: bold; margin-top: 8px; }
+        .label .sku { font-size: 12px; color: #555; margin-top: 4px; font-family: monospace; }
+        .no-print { margin-bottom: 20px; }
+        @media print {
+            .no-print { display: none !important; }
+            body { padding: 10px; }
+        }
+    </style>
+</head>
+<body>
+    <div class="no-print">
+        <button onclick="window.print()" style="padding:8px 16px;cursor:pointer;">印刷する</button>
+        <a href="{{ route('products.show', $product) }}" style="margin-left:12px;">戻る</a>
+    </div>
+    <div class="label">
+        <img src="{{ route('products.qrcode', $product) }}" width="180" height="180" alt="QR">
+        <div class="name">{{ $product->name }}</div>
+        <div class="sku">{{ $product->sku }}</div>
+    </div>
+</body>
+</html>

--- a/resources/views/products/show.blade.php
+++ b/resources/views/products/show.blade.php
@@ -1,0 +1,186 @@
+@extends('layouts.app')
+
+@section('title', $product->name . ' - 商品詳細')
+
+@section('content')
+<div class="d-flex justify-content-between align-items-center mt-4 mb-3">
+    <h2><i class="bi bi-box-seam me-2"></i>{{ $product->name }}</h2>
+    <div class="d-flex gap-2">
+        <a href="{{ route('products.edit', $product) }}" class="btn btn-outline-secondary">
+            <i class="bi bi-pencil me-1"></i>編集
+        </a>
+        <a href="{{ route('products.index') }}" class="btn btn-outline-secondary">
+            <i class="bi bi-arrow-left me-1"></i>一覧へ
+        </a>
+    </div>
+</div>
+
+<div class="row g-4">
+    {{-- 左カラム: 商品情報 + QRコード --}}
+    <div class="col-md-4">
+        {{-- 商品情報 --}}
+        <div class="card mb-4">
+            <div class="card-header fw-semibold">
+                <i class="bi bi-info-circle me-1"></i>商品情報
+            </div>
+            <div class="card-body">
+                <dl class="row mb-0">
+                    <dt class="col-5 text-muted">SKU</dt>
+                    <dd class="col-7"><code>{{ $product->sku }}</code></dd>
+
+                    <dt class="col-5 text-muted">商品名</dt>
+                    <dd class="col-7">{{ $product->name }}</dd>
+
+                    <dt class="col-5 text-muted">在庫数</dt>
+                    <dd class="col-7">
+                        <span class="fs-5 fw-bold {{ $product->isOutOfStock() ? 'text-danger' : 'text-success' }}">
+                            {{ number_format($product->stock_quantity) }}
+                        </span>
+                    </dd>
+
+                    <dt class="col-5 text-muted">発注点</dt>
+                    <dd class="col-7">{{ number_format($product->reorder_point) }}</dd>
+
+                    <dt class="col-5 text-muted">ステータス</dt>
+                    <dd class="col-7">
+                        @if($product->isOutOfStock())
+                            <span class="badge bg-danger">在庫切れ</span>
+                        @elseif($product->isBelowReorderPoint())
+                            <span class="badge bg-warning text-dark">要発注</span>
+                        @else
+                            <span class="badge bg-success">正常</span>
+                        @endif
+                    </dd>
+
+                    @if($product->description)
+                    <dt class="col-5 text-muted">説明</dt>
+                    <dd class="col-7">{{ $product->description }}</dd>
+                    @endif
+                </dl>
+            </div>
+        </div>
+
+        {{-- QRコード --}}
+        <div class="card" id="qrcode">
+            <div class="card-header fw-semibold">
+                <i class="bi bi-qr-code me-1"></i>QRコード
+            </div>
+            <div class="card-body text-center">
+                <p class="text-muted small mb-3">
+                    スキャンすると商品詳細ページへアクセスできます
+                </p>
+                <div class="d-inline-block border rounded p-2 bg-white">
+                    <img src="{{ route('products.qrcode', $product) }}"
+                         alt="QRコード - {{ $product->sku }}"
+                         width="200" height="200">
+                </div>
+                <p class="text-muted small mt-2 mb-3">
+                    <code>{{ $product->sku }}</code>
+                </p>
+                <a href="{{ route('products.qrcode.download', $product) }}"
+                   class="btn btn-outline-primary btn-sm">
+                    <i class="bi bi-download me-1"></i>PNGダウンロード
+                </a>
+                <a href="{{ route('products.label', $product) }}"
+                   class="btn btn-outline-secondary btn-sm ms-1" target="_blank">
+                    <i class="bi bi-tag me-1"></i>ラベル印刷
+                </a>
+            </div>
+        </div>
+    </div>
+
+    {{-- 右カラム: 在庫操作 + 履歴 --}}
+    <div class="col-md-8">
+        {{-- 在庫操作フォーム --}}
+        <div class="card mb-4">
+            <div class="card-header fw-semibold">
+                <i class="bi bi-arrow-left-right me-1"></i>在庫操作
+            </div>
+            <div class="card-body">
+                @if($errors->any())
+                    <div class="alert alert-danger">
+                        @foreach($errors->all() as $error)
+                            <div>{{ $error }}</div>
+                        @endforeach
+                    </div>
+                @endif
+
+                <form method="POST" action="{{ route('stock-transactions.store', $product) }}">
+                    @csrf
+                    <div class="row g-3">
+                        <div class="col-md-4">
+                            <label class="form-label fw-semibold">操作種別</label>
+                            <select name="type" class="form-select" required>
+                                <option value="IN" @selected(old('type')==='IN')>入庫</option>
+                                <option value="OUT" @selected(old('type')==='OUT')>出庫</option>
+                                <option value="ADJUST" @selected(old('type')==='ADJUST')>在庫調整</option>
+                            </select>
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label fw-semibold">数量</label>
+                            <input type="number" name="quantity" class="form-control"
+                                   min="1" value="{{ old('quantity', 1) }}" required>
+                        </div>
+                        <div class="col-md-5">
+                            <label class="form-label fw-semibold">理由・メモ</label>
+                            <input type="text" name="reason" class="form-control"
+                                   placeholder="任意" value="{{ old('reason') }}">
+                        </div>
+                        <div class="col-12">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="bi bi-check2 me-1"></i>実行
+                            </button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        {{-- 在庫履歴 --}}
+        <div class="card">
+            <div class="card-header fw-semibold">
+                <i class="bi bi-clock-history me-1"></i>在庫履歴
+            </div>
+            <div class="card-body p-0">
+                <table class="table table-sm mb-0">
+                    <thead>
+                        <tr>
+                            <th>日時</th>
+                            <th>種別</th>
+                            <th class="text-end">数量</th>
+                            <th>理由</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse($transactions as $tx)
+                        <tr>
+                            <td class="text-muted small">{{ $tx->created_at->format('Y/m/d H:i') }}</td>
+                            <td>
+                                @if($tx->type->value === 'IN')
+                                    <span class="badge bg-success">入庫</span>
+                                @elseif($tx->type->value === 'OUT')
+                                    <span class="badge bg-danger">出庫</span>
+                                @else
+                                    <span class="badge bg-secondary">調整</span>
+                                @endif
+                            </td>
+                            <td class="text-end fw-semibold">{{ number_format($tx->quantity) }}</td>
+                            <td class="text-muted small">{{ $tx->reason ?? '-' }}</td>
+                        </tr>
+                        @empty
+                        <tr>
+                            <td colspan="4" class="text-center text-muted py-3">履歴がありません</td>
+                        </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+            @if($transactions->hasPages())
+            <div class="card-footer">
+                {{ $transactions->links() }}
+            </div>
+            @endif
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,167 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AccommodationController;
+use App\Http\Controllers\RoomController;
+use App\Http\Controllers\CustomerController;
+use App\Http\Controllers\ReservationController;
+use App\Http\Controllers\PaymentController;
+use App\Http\Controllers\ReviewController;
+use App\Http\Controllers\ReportController;
+use App\Http\Controllers\ProductController;
+use App\Http\Controllers\StockTransactionController;
+use App\Http\Controllers\ElectionController;
+use App\Http\Controllers\TravelController;
+use App\Http\Controllers\EventController;
+use App\Models\Accommodation;
+use App\Models\Room;
+use App\Models\Customer;
+use App\Models\Reservation;
+use App\Models\PricingRule;
+use App\Models\RoomInventory;
+use App\Models\Payment;
+use App\Models\Review;
+use App\Services\ReservationService;
+use App\Services\PricingService;
+use App\Services\InventoryService;
+use App\Services\PaymentService;
+use App\Services\NotificationService;
+use App\Services\ReportService;
+
+Route::get('/', function () {
+    return view('welcome');
+});
+
+// 管理系リソース (認証必須)
+Route::middleware('auth')->group(function () {
+    Route::resource('accommodations', AccommodationController::class);
+    Route::resource('rooms', RoomController::class);
+    Route::resource('customers', CustomerController::class);
+    Route::resource('reservations', ReservationController::class);
+    Route::resource('payments', PaymentController::class);
+    Route::resource('reviews', ReviewController::class);
+
+    // ===== 在庫管理システム =====
+    Route::resource('products', ProductController::class);
+    Route::get('/products/{product}/qrcode', [ProductController::class, 'qrcode'])->name('products.qrcode');
+    Route::get('/products/{product}/qrcode/download', [ProductController::class, 'qrcodeDownload'])->name('products.qrcode.download');
+    Route::get('/products/{product}/label', [ProductController::class, 'label'])->name('products.label');
+    Route::post('/products/{product}/stock-transactions', [StockTransactionController::class, 'store'])->name('stock-transactions.store');
+    Route::get('/stock-transactions', [StockTransactionController::class, 'index'])->name('stock-transactions.index');
+
+    // 決済関連のカスタムルート
+    Route::post('/payments/{payment}/process', [PaymentController::class, 'process'])->name('payments.process');
+    Route::post('/payments/{payment}/refund', [PaymentController::class, 'refund'])->name('payments.refund');
+    Route::post('/payments/{payment}/cancel', [PaymentController::class, 'cancel'])->name('payments.cancel');
+
+    // レビュー関連のカスタムルート
+    Route::post('/reviews/{review}/helpful', [ReviewController::class, 'addHelpfulVote'])->name('reviews.helpful');
+    Route::post('/reviews/{review}/admin-response', [ReviewController::class, 'addAdminResponse'])->name('reviews.admin-response');
+});
+
+// レポート関連のルート (認証必須)
+Route::middleware('auth')->group(function () {
+    Route::get('/reports/dashboard', [ReportController::class, 'dashboard'])->name('reports.dashboard');
+    Route::get('/reports/reservations', [ReportController::class, 'reservations'])->name('reports.reservations');
+    Route::get('/reports/revenue', [ReportController::class, 'revenue'])->name('reports.revenue');
+    Route::get('/reports/occupancy', [ReportController::class, 'occupancy'])->name('reports.occupancy');
+    Route::get('/reports/reviews', [ReportController::class, 'reviews'])->name('reports.reviews');
+    Route::get('/reports/customers', [ReportController::class, 'customers'])->name('reports.customers');
+    Route::get('/reports/export', [ReportController::class, 'export'])->name('reports.export');
+});
+
+// ===== 旅行検索サイト =====
+
+// トップ・検索
+Route::get('/travel', [TravelController::class, 'index'])->name('travel.index');
+Route::get('/travel/search', [TravelController::class, 'search'])->name('travel.search');
+Route::get('/travel/suggest', [TravelController::class, 'suggest'])->name('travel.suggest');
+
+// 施設詳細
+Route::get('/travel/accommodations/{id}', [TravelController::class, 'show'])->name('travel.show');
+Route::get('/travel/accommodations/{id}/plans', [TravelController::class, 'searchPlans'])->name('travel.plans');
+Route::get('/travel/accommodations/{id}/reviews', [TravelController::class, 'reviews'])->name('travel.reviews');
+
+// 予約フロー
+Route::get('/travel/booking/{plan}', [TravelController::class, 'booking'])->name('travel.booking');
+Route::post('/travel/booking/confirm', [TravelController::class, 'confirmBooking'])->name('travel.booking.confirm');
+Route::post('/travel/booking/complete', [TravelController::class, 'completeBooking'])->name('travel.booking.complete');
+
+// お気に入り
+Route::post('/travel/favorites', [TravelController::class, 'addFavorite'])->name('travel.favorites.add');
+Route::delete('/travel/favorites/{accommodation}', [TravelController::class, 'removeFavorite'])->name('travel.favorites.remove');
+
+// エリアAPI
+Route::get('/travel/areas', [TravelController::class, 'areas'])->name('travel.areas');
+
+// ===== イベント検索システム =====
+
+// トップ・検索
+Route::get('/events', [EventController::class, 'index'])->name('events.index');
+Route::get('/events/search', [EventController::class, 'search'])->name('events.search');
+Route::get('/events/calendar', [EventController::class, 'calendar'])->name('events.calendar');
+
+// イベント詳細
+Route::get('/events/{id}', [EventController::class, 'show'])->name('events.show');
+
+// お気に入り
+Route::get('/events/my/favorites', [EventController::class, 'favorites'])->name('events.favorites');
+Route::post('/events/favorites', [EventController::class, 'addFavorite'])->name('events.favorites.add');
+Route::delete('/events/favorites/{eventId}', [EventController::class, 'removeFavorite'])->name('events.favorites.remove');
+
+// API
+Route::get('/api/events/search', [EventController::class, 'apiSearch'])->name('events.api.search');
+
+// ===== 選挙分析システム =====
+
+// ダッシュボード
+Route::get('/elections/dashboard', [ElectionController::class, 'dashboard'])->name('elections.dashboard');
+
+// 選挙関連
+Route::get('/elections', [ElectionController::class, 'index'])->name('elections.index');
+Route::post('/elections', [ElectionController::class, 'store'])->name('elections.store');
+Route::get('/elections/{election}', [ElectionController::class, 'show'])->name('elections.show');
+
+// 議席予測
+Route::post('/elections/{election}/predict', [ElectionController::class, 'predict'])->name('elections.predict');
+Route::get('/elections/{election}/predictions', [ElectionController::class, 'getPredictions'])->name('elections.predictions');
+Route::get('/elections/{election}/validate-accuracy', [ElectionController::class, 'validateAccuracy'])->name('elections.validate-accuracy');
+
+// 選挙比較
+Route::get('/elections-compare', [ElectionController::class, 'compare'])->name('elections.compare');
+
+// 選挙結果登録
+Route::post('/elections/{election}/results', [ElectionController::class, 'storeResult'])->name('elections.results.store');
+
+// 世論調査データ
+Route::get('/poll-data', [ElectionController::class, 'pollData'])->name('poll-data.index');
+Route::post('/poll-data', [ElectionController::class, 'storePollData'])->name('poll-data.store');
+
+// 政党関連
+Route::get('/parties', [ElectionController::class, 'parties'])->name('parties.index');
+Route::post('/parties', [ElectionController::class, 'storeParty'])->name('parties.store');
+Route::get('/parties/{party}/trend', [ElectionController::class, 'partyTrend'])->name('parties.trend');
+
+// 選挙区関連
+Route::get('/election-districts', [ElectionController::class, 'districts'])->name('districts.index');
+
+// インポート・エクスポート
+Route::post('/elections/import-csv', [ElectionController::class, 'importCsv'])->name('elections.import-csv');
+Route::get('/elections/{election}/export', [ElectionController::class, 'exportReport'])->name('elections.export');
+
+// ===== テスト用ルート (local環境のみ) =====
+if (!app()->environment('local', 'testing')) {
+    return;
+}
+
+// データベース状態確認
+Route::get('/test-db-status', function () {
+    return response()->json([
+        'accommodations' => Accommodation::count(),
+        'rooms' => Room::count(),
+        'customers' => Customer::count(),
+        'reservations' => Reservation::count(),
+        'pricing_rules' => PricingRule::count(),
+        'room_inventories' => RoomInventory::count(),
+    ]);
+});


### PR DESCRIPTION
## Summary

- Adds `label()` method to `ProductController` returning a standalone print-optimized label page
- New `products/qr-label.blade.php` — full HTML page (no layout inheritance) with bordered label showing QR image, product name, and SKU
- `GET /products/{product}/label` route added; opens in new tab
- "ラベル印刷" button added to the QR code card on the product detail page

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjEM2ZSQARW5aVzEA72VJN)_