### PR TITLE
feat: quick +1/-1 stock adjustment buttons on product list

### DIFF
--- a/app/Http/Controllers/StockTransactionController.php
+++ b/app/Http/Controllers/StockTransactionController.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\StockTransactionType;
+use App\Http\Requests\StockOperationRequest;
+use App\Models\Product;
+use App\Services\StockService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * 在庫操作コントローラー
+ *
+ * WHY: 在庫の入出庫操作はServiceに完全委譲し、Controllerは薄く保つ
+ */
+class StockTransactionController extends Controller
+{
+    public function __construct(
+        private StockService $stockService
+    ) {}
+
+    /**
+     * 在庫操作実行（入庫/出庫/調整）
+     */
+    public function store(StockOperationRequest $request, Product $product)
+    {
+        try {
+            $type = StockTransactionType::from($request->input('type'));
+            $quantity = $request->integer('quantity');
+            $reason = $request->input('reason');
+
+            // WHY: 操作種別に応じて適切なServiceメソッドを呼び出す
+            $transaction = match ($type) {
+                StockTransactionType::IN => $this->stockService->stockIn(
+                    $product,
+                    $quantity,
+                    $reason
+                ),
+                StockTransactionType::OUT => $this->stockService->stockOut(
+                    $product,
+                    $quantity,
+                    $reason
+                ),
+                StockTransactionType::ADJUST => $this->stockService->adjust(
+                    $product,
+                    $quantity,
+                    $reason
+                ),
+            };
+
+            return redirect()
+                ->route('products.show', $product)
+                ->with('success', "{$type->label()}処理が完了しました");
+
+        } catch (\InvalidArgumentException $e) {
+            return back()
+                ->withErrors(['quantity' => $e->getMessage()])
+                ->withInput();
+        } catch (\Exception $e) {
+            Log::error('Stock operation failed', [
+                'product_id' => $product->id,
+                'type' => $request->input('type'),
+                'error' => $e->getMessage(),
+            ]);
+
+            return back()
+                ->withErrors(['error' => '在庫操作に失敗しました'])
+                ->withInput();
+        }
+    }
+
+    /**
+     * 在庫履歴一覧
+     */
+    public function index(Request $request)
+    {
+        $query = \App\Models\StockTransaction::query()
+            ->with('product');
+
+        // フィルタ
+        if ($request->filled('type')) {
+            $query->where('type', $request->input('type'));
+        }
+
+        if ($request->filled('product_id')) {
+            $query->where('product_id', $request->integer('product_id'));
+        }
+
+        $transactions = $query->latest()->paginate(50);
+
+        return view('stock-transactions.index', compact('transactions'));
+    }
+
+    /**
+     * Quick +1/-1 stock adjust via JSON for the products index page buttons.
+     */
+    public function quickAdjust(Request $request, Product $product)
+    {
+        $delta = $request->integer('delta');
+        if (!in_array($delta, [-1, 1], true)) {
+            return response()->json(['error' => 'invalid delta'], 422);
+        }
+
+        try {
+            if ($delta > 0) {
+                $this->stockService->stockIn($product, 1, 'クイック入庫');
+            } else {
+                $this->stockService->stockOut($product, 1, 'クイック出庫');
+            }
+            $product->refresh();
+            return response()->json(['stock' => $product->stock_quantity]);
+        } catch (\InvalidArgumentException $e) {
+            return response()->json(['error' => $e->getMessage()], 422);
+        }
+    }
+}

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -1,0 +1,164 @@
+@extends('layouts.app')
+
+@section('title', '商品一覧 - 在庫管理')
+
+@section('content')
+<div class="d-flex justify-content-between align-items-center mt-4 mb-3">
+    <h2><i class="bi bi-box-seam me-2"></i>商品一覧</h2>
+    <a href="{{ route('products.create') }}" class="btn btn-primary">
+        <i class="bi bi-plus-circle me-1"></i>商品登録
+    </a>
+</div>
+
+{{-- 検索フォーム --}}
+<div class="card mb-4">
+    <div class="card-body">
+        <form method="GET" action="{{ route('products.index') }}" class="row g-2 align-items-end">
+            <div class="col-md-5">
+                <label class="form-label fw-semibold">検索</label>
+                <input type="text" name="search" class="form-control" placeholder="SKU・商品名で検索"
+                    value="{{ request('search') }}">
+            </div>
+            <div class="col-md-3">
+                <label class="form-label fw-semibold">並び替え</label>
+                <select name="sort" class="form-select">
+                    <option value="stock_asc" @selected(request('sort','stock_asc')==='stock_asc')>在庫が少ない順</option>
+                    <option value="stock_desc" @selected(request('sort')==='stock_desc')>在庫が多い順</option>
+                    <option value="name" @selected(request('sort')==='name')>商品名順</option>
+                </select>
+            </div>
+            <div class="col-md-2">
+                <div class="form-check mt-4">
+                    <input class="form-check-input" type="checkbox" name="alert_only" value="1" id="alertOnly"
+                        @checked(request('alert_only'))>
+                    <label class="form-check-label" for="alertOnly">アラートのみ</label>
+                </div>
+            </div>
+            <div class="col-md-2 d-flex gap-2">
+                <button type="submit" class="btn btn-primary w-100">
+                    <i class="bi bi-search"></i>
+                </button>
+                <a href="{{ route('products.index') }}" class="btn btn-secondary w-100">
+                    <i class="bi bi-x-lg"></i>
+                </a>
+            </div>
+        </form>
+    </div>
+</div>
+
+{{-- 商品テーブル --}}
+<div class="card">
+    <div class="card-body p-0">
+        <table class="table table-hover mb-0">
+            <thead>
+                <tr>
+                    <th>SKU</th>
+                    <th>商品名</th>
+                    <th class="text-end">在庫数</th>
+                    <th class="text-end">発注点</th>
+                    <th class="text-center">ステータス</th>
+                    <th class="text-center">QRコード</th>
+                    <th class="text-center">操作</th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse($products as $product)
+                <tr class="{{ $product->isBelowReorderPoint() ? 'table-warning' : '' }}">
+                    <td><code>{{ $product->sku }}</code></td>
+                    <td>
+                        <a href="{{ route('products.show', $product) }}" class="text-decoration-none fw-semibold">
+                            {{ $product->name }}
+                        </a>
+                    </td>
+                    <td class="text-end fw-bold {{ $product->isOutOfStock() ? 'text-danger' : '' }}">
+                        <span class="stock-display" data-id="{{ $product->id }}">{{ number_format($product->stock_quantity) }}</span>
+                        <button class="btn btn-sm btn-outline-success py-0 px-1 ms-1 quick-btn"
+                                data-url="{{ route('stock-transactions.quick-adjust', $product) }}"
+                                data-delta="1" title="+1入庫">＋</button>
+                        <button class="btn btn-sm btn-outline-danger py-0 px-1 quick-btn"
+                                data-url="{{ route('stock-transactions.quick-adjust', $product) }}"
+                                data-delta="-1" title="-1出庫">－</button>
+                    </td>
+                    <td class="text-end text-muted">{{ number_format($product->reorder_point) }}</td>
+                    <td class="text-center">
+                        @if($product->isOutOfStock())
+                            <span class="badge bg-danger">在庫切れ</span>
+                        @elseif($product->isBelowReorderPoint())
+                            <span class="badge bg-warning text-dark">要発注</span>
+                        @else
+                            <span class="badge bg-success">正常</span>
+                        @endif
+                    </td>
+                    <td class="text-center">
+                        <a href="{{ route('products.show', $product) }}#qrcode"
+                            class="btn btn-sm btn-outline-secondary" title="QRコードを表示">
+                            <i class="bi bi-qr-code"></i>
+                        </a>
+                        <a href="{{ route('products.qrcode.download', $product) }}"
+                            class="btn btn-sm btn-outline-secondary" title="QRコードをダウンロード">
+                            <i class="bi bi-download"></i>
+                        </a>
+                    </td>
+                    <td class="text-center">
+                        <a href="{{ route('products.show', $product) }}" class="btn btn-sm btn-outline-primary">
+                            <i class="bi bi-eye"></i>
+                        </a>
+                        <a href="{{ route('products.edit', $product) }}" class="btn btn-sm btn-outline-secondary">
+                            <i class="bi bi-pencil"></i>
+                        </a>
+                        <form method="POST" action="{{ route('products.destroy', $product) }}" class="d-inline"
+                            onsubmit="return confirm('削除しますか？')">
+                            @csrf @method('DELETE')
+                            <button type="submit" class="btn btn-sm btn-outline-danger">
+                                <i class="bi bi-trash"></i>
+                            </button>
+                        </form>
+                    </td>
+                </tr>
+                @empty
+                <tr>
+                    <td colspan="7" class="text-center text-muted py-4">
+                        商品が登録されていません
+                    </td>
+                </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<div class="mt-3">
+    {{ $products->withQueryString()->links() }}
+</div>
+@endsection
+
+@push('scripts')
+<script>
+document.querySelectorAll('.quick-btn').forEach(btn => {
+    btn.addEventListener('click', async function() {
+        const url = this.dataset.url;
+        const delta = parseInt(this.dataset.delta);
+        const row = this.closest('tr');
+        const display = row.querySelector('.stock-display');
+        try {
+            const res = await fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
+                },
+                body: JSON.stringify({ delta })
+            });
+            const data = await res.json();
+            if (res.ok) {
+                display.textContent = data.stock.toLocaleString();
+            } else {
+                alert(data.error || '操作に失敗しました');
+            }
+        } catch (e) {
+            alert('通信エラーが発生しました');
+        }
+    });
+});
+</script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,167 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AccommodationController;
+use App\Http\Controllers\RoomController;
+use App\Http\Controllers\CustomerController;
+use App\Http\Controllers\ReservationController;
+use App\Http\Controllers\PaymentController;
+use App\Http\Controllers\ReviewController;
+use App\Http\Controllers\ReportController;
+use App\Http\Controllers\ProductController;
+use App\Http\Controllers\StockTransactionController;
+use App\Http\Controllers\ElectionController;
+use App\Http\Controllers\TravelController;
+use App\Http\Controllers\EventController;
+use App\Models\Accommodation;
+use App\Models\Room;
+use App\Models\Customer;
+use App\Models\Reservation;
+use App\Models\PricingRule;
+use App\Models\RoomInventory;
+use App\Models\Payment;
+use App\Models\Review;
+use App\Services\ReservationService;
+use App\Services\PricingService;
+use App\Services\InventoryService;
+use App\Services\PaymentService;
+use App\Services\NotificationService;
+use App\Services\ReportService;
+
+Route::get('/', function () {
+    return view('welcome');
+});
+
+// 管理系リソース (認証必須)
+Route::middleware('auth')->group(function () {
+    Route::resource('accommodations', AccommodationController::class);
+    Route::resource('rooms', RoomController::class);
+    Route::resource('customers', CustomerController::class);
+    Route::resource('reservations', ReservationController::class);
+    Route::resource('payments', PaymentController::class);
+    Route::resource('reviews', ReviewController::class);
+
+    // ===== 在庫管理システム =====
+    Route::resource('products', ProductController::class);
+    Route::get('/products/{product}/qrcode', [ProductController::class, 'qrcode'])->name('products.qrcode');
+    Route::get('/products/{product}/qrcode/download', [ProductController::class, 'qrcodeDownload'])->name('products.qrcode.download');
+    Route::post('/products/{product}/stock-transactions', [StockTransactionController::class, 'store'])->name('stock-transactions.store');
+    Route::post('/products/{product}/quick-adjust', [StockTransactionController::class, 'quickAdjust'])->name('stock-transactions.quick-adjust');
+    Route::get('/stock-transactions', [StockTransactionController::class, 'index'])->name('stock-transactions.index');
+
+    // 決済関連のカスタムルート
+    Route::post('/payments/{payment}/process', [PaymentController::class, 'process'])->name('payments.process');
+    Route::post('/payments/{payment}/refund', [PaymentController::class, 'refund'])->name('payments.refund');
+    Route::post('/payments/{payment}/cancel', [PaymentController::class, 'cancel'])->name('payments.cancel');
+
+    // レビュー関連のカスタムルート
+    Route::post('/reviews/{review}/helpful', [ReviewController::class, 'addHelpfulVote'])->name('reviews.helpful');
+    Route::post('/reviews/{review}/admin-response', [ReviewController::class, 'addAdminResponse'])->name('reviews.admin-response');
+});
+
+// レポート関連のルート (認証必須)
+Route::middleware('auth')->group(function () {
+    Route::get('/reports/dashboard', [ReportController::class, 'dashboard'])->name('reports.dashboard');
+    Route::get('/reports/reservations', [ReportController::class, 'reservations'])->name('reports.reservations');
+    Route::get('/reports/revenue', [ReportController::class, 'revenue'])->name('reports.revenue');
+    Route::get('/reports/occupancy', [ReportController::class, 'occupancy'])->name('reports.occupancy');
+    Route::get('/reports/reviews', [ReportController::class, 'reviews'])->name('reports.reviews');
+    Route::get('/reports/customers', [ReportController::class, 'customers'])->name('reports.customers');
+    Route::get('/reports/export', [ReportController::class, 'export'])->name('reports.export');
+});
+
+// ===== 旅行検索サイト =====
+
+// トップ・検索
+Route::get('/travel', [TravelController::class, 'index'])->name('travel.index');
+Route::get('/travel/search', [TravelController::class, 'search'])->name('travel.search');
+Route::get('/travel/suggest', [TravelController::class, 'suggest'])->name('travel.suggest');
+
+// 施設詳細
+Route::get('/travel/accommodations/{id}', [TravelController::class, 'show'])->name('travel.show');
+Route::get('/travel/accommodations/{id}/plans', [TravelController::class, 'searchPlans'])->name('travel.plans');
+Route::get('/travel/accommodations/{id}/reviews', [TravelController::class, 'reviews'])->name('travel.reviews');
+
+// 予約フロー
+Route::get('/travel/booking/{plan}', [TravelController::class, 'booking'])->name('travel.booking');
+Route::post('/travel/booking/confirm', [TravelController::class, 'confirmBooking'])->name('travel.booking.confirm');
+Route::post('/travel/booking/complete', [TravelController::class, 'completeBooking'])->name('travel.booking.complete');
+
+// お気に入り
+Route::post('/travel/favorites', [TravelController::class, 'addFavorite'])->name('travel.favorites.add');
+Route::delete('/travel/favorites/{accommodation}', [TravelController::class, 'removeFavorite'])->name('travel.favorites.remove');
+
+// エリアAPI
+Route::get('/travel/areas', [TravelController::class, 'areas'])->name('travel.areas');
+
+// ===== イベント検索システム =====
+
+// トップ・検索
+Route::get('/events', [EventController::class, 'index'])->name('events.index');
+Route::get('/events/search', [EventController::class, 'search'])->name('events.search');
+Route::get('/events/calendar', [EventController::class, 'calendar'])->name('events.calendar');
+
+// イベント詳細
+Route::get('/events/{id}', [EventController::class, 'show'])->name('events.show');
+
+// お気に入り
+Route::get('/events/my/favorites', [EventController::class, 'favorites'])->name('events.favorites');
+Route::post('/events/favorites', [EventController::class, 'addFavorite'])->name('events.favorites.add');
+Route::delete('/events/favorites/{eventId}', [EventController::class, 'removeFavorite'])->name('events.favorites.remove');
+
+// API
+Route::get('/api/events/search', [EventController::class, 'apiSearch'])->name('events.api.search');
+
+// ===== 選挙分析システム =====
+
+// ダッシュボード
+Route::get('/elections/dashboard', [ElectionController::class, 'dashboard'])->name('elections.dashboard');
+
+// 選挙関連
+Route::get('/elections', [ElectionController::class, 'index'])->name('elections.index');
+Route::post('/elections', [ElectionController::class, 'store'])->name('elections.store');
+Route::get('/elections/{election}', [ElectionController::class, 'show'])->name('elections.show');
+
+// 議席予測
+Route::post('/elections/{election}/predict', [ElectionController::class, 'predict'])->name('elections.predict');
+Route::get('/elections/{election}/predictions', [ElectionController::class, 'getPredictions'])->name('elections.predictions');
+Route::get('/elections/{election}/validate-accuracy', [ElectionController::class, 'validateAccuracy'])->name('elections.validate-accuracy');
+
+// 選挙比較
+Route::get('/elections-compare', [ElectionController::class, 'compare'])->name('elections.compare');
+
+// 選挙結果登録
+Route::post('/elections/{election}/results', [ElectionController::class, 'storeResult'])->name('elections.results.store');
+
+// 世論調査データ
+Route::get('/poll-data', [ElectionController::class, 'pollData'])->name('poll-data.index');
+Route::post('/poll-data', [ElectionController::class, 'storePollData'])->name('poll-data.store');
+
+// 政党関連
+Route::get('/parties', [ElectionController::class, 'parties'])->name('parties.index');
+Route::post('/parties', [ElectionController::class, 'storeParty'])->name('parties.store');
+Route::get('/parties/{party}/trend', [ElectionController::class, 'partyTrend'])->name('parties.trend');
+
+// 選挙区関連
+Route::get('/election-districts', [ElectionController::class, 'districts'])->name('districts.index');
+
+// インポート・エクスポート
+Route::post('/elections/import-csv', [ElectionController::class, 'importCsv'])->name('elections.import-csv');
+Route::get('/elections/{election}/export', [ElectionController::class, 'exportReport'])->name('elections.export');
+
+// ===== テスト用ルート (local環境のみ) =====
+if (!app()->environment('local', 'testing')) {
+    return;
+}
+
+// データベース状態確認
+Route::get('/test-db-status', function () {
+    return response()->json([
+        'accommodations' => Accommodation::count(),
+        'rooms' => Room::count(),
+        'customers' => Customer::count(),
+        'reservations' => Reservation::count(),
+        'pricing_rules' => PricingRule::count(),
+        'room_inventories' => RoomInventory::count(),
+    ]);
+});


### PR DESCRIPTION
## Summary

- Adds `quickAdjust()` JSON endpoint to `StockTransactionController` accepting `delta` of `+1` or `-1`
- `POST /products/{product}/quick-adjust` route with CSRF protection
- `＋` / `－` buttons inline in the stock quantity cell of the product list table
- Fetch-based JS updates the displayed count without a full page reload; shows `alert()` on error

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjEM2ZSQARW5aVzEA72VJN)_