### PR TITLE
fix: narrow Review model mass assignment to prevent privilege escalation

### DIFF
--- a/laravel_project/app/Models/Review.php
+++ b/laravel_project/app/Models/Review.php
@@ -24,6 +24,9 @@ class Review extends Model
         'title',
         'comment',
         'photos',
+    ];
+
+    protected $guarded = [
         'is_verified',
         'is_published',
         'admin_response',
@@ -102,7 +105,8 @@ class Review extends Model
      */
     public function publish(): void
     {
-        $this->update(['is_published' => true]);
+        $this->is_published = true;
+        $this->save();
     }
 
     /**
@@ -110,7 +114,8 @@ class Review extends Model
      */
     public function unpublish(): void
     {
-        $this->update(['is_published' => false]);
+        $this->is_published = false;
+        $this->save();
     }
 
     /**
@@ -118,7 +123,8 @@ class Review extends Model
      */
     public function verify(): void
     {
-        $this->update(['is_verified' => true]);
+        $this->is_verified = true;
+        $this->save();
     }
 
     /**
@@ -126,10 +132,9 @@ class Review extends Model
      */
     public function addAdminResponse(string $response): void
     {
-        $this->update([
-            'admin_response' => $response,
-            'admin_responded_at' => now(),
-        ]);
+        $this->admin_response = $response;
+        $this->admin_responded_at = now();
+        $this->save();
     }
 
     /**


### PR DESCRIPTION
## Summary

- Remove admin-only fields (`is_verified`, `is_published`, `admin_response`, `admin_responded_at`, `helpful_count`) from `$fillable` in the `Review` model
- Add those fields to `$guarded` so users cannot set them via mass assignment (e.g. `Review::create($request->all())`)
- Convert `publish()`, `unpublish()`, `verify()`, `addAdminResponse()` from `$this->update([...])` to direct property assignment + `$this->save()` so internal model methods still work correctly after tightening the guard

## Security Impact

Without this fix, a malicious user could submit a crafted POST request with `is_published=1` or `is_verified=1` to auto-publish or auto-verify their own review, bypassing admin moderation. They could also inject arbitrary `admin_response` content or inflate `helpful_count`.

## Test plan

- [ ] Submit a review creation request with `is_published=true` — confirm it remains unpublished
- [ ] Submit a review creation request with `is_verified=true` — confirm it remains unverified
- [ ] Call `$review->publish()` — confirm `is_published` becomes `true` and is saved
- [ ] Call `$review->verify()` — confirm `is_verified` becomes `true` and is saved
- [ ] Call `$review->addAdminResponse('text')` — confirm `admin_response` and `admin_responded_at` are saved


---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_