### PR TITLE
fix: add input validation to ElectionController index and pollData

### DIFF
--- a/laravel_project/app/Http/Controllers/ElectionController.php
+++ b/laravel_project/app/Http/Controllers/ElectionController.php
@@ -86,9 +86,15 @@ class ElectionController extends Controller
      */
     public function index(Request $request): JsonResponse
     {
-        $type = $request->input('type'); // house_of_representatives / house_of_councillors
-        $fromYear = $request->input('from_year', 2010);
-        $toYear = $request->input('to_year', 2026);
+        $request->validate([
+            'type'      => 'nullable|in:house_of_representatives,house_of_councillors',
+            'from_year' => 'nullable|integer|min:1900|max:2100',
+            'to_year'   => 'nullable|integer|min:1900|max:2100|gte:from_year',
+        ]);
+
+        $type = $request->input('type');
+        $fromYear = (int) $request->input('from_year', 2010);
+        $toYear   = (int) $request->input('to_year', 2026);
 
         $elections = $this->dataService->getElections($type, $fromYear, $toYear);
 
@@ -222,6 +228,13 @@ class ElectionController extends Controller
      */
     public function pollData(Request $request): JsonResponse
     {
+        $request->validate([
+            'election_id' => 'nullable|integer|exists:elections,id',
+            'source'      => 'nullable|string|max:100',
+            'start_date'  => 'nullable|date|after_or_equal:1900-01-01',
+            'end_date'    => 'nullable|date|after_or_equal:start_date',
+        ]);
+
         $electionId = $request->input('election_id');
         $source = $request->input('source');
         $startDate = $request->input('start_date') ? Carbon::parse($request->input('start_date')) : null;


### PR DESCRIPTION
## Summary

- `index()`: validate `type` against an enum whitelist (`house_of_representatives`, `house_of_councillors`), and validate `from_year`/`to_year` as integers in range 1900–2100 to prevent type confusion and unexpected query behaviour
- `pollData()`: validate `election_id` via `exists:elections,id`, cap `source` at 100 characters, and validate `start_date`/`end_date` as proper dates before passing to `Carbon::parse()` to prevent a Carbon exception crash on a public endpoint

## Security Impact

Without this fix, a request to `GET /api/elections?type=<injection>` or `GET /api/polls?start_date=not-a-date` would cause unhandled exceptions or pass un-sanitised strings to the data service. `pollData()` is a public endpoint, making the `Carbon::parse()` call on unvalidated input a DoS vector.

## Test plan

- [ ] `GET /api/elections?type=invalid` returns 422
- [ ] `GET /api/elections?from_year=abc` returns 422
- [ ] `GET /api/polls?start_date=not-a-date` returns 422 instead of 500
- [ ] `GET /api/polls?election_id=99999` returns 422 (non-existent id)
- [ ] Valid requests continue to work normally


---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_