### PR TITLE
feat: add SVG format download for QR codes

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Product;
+use Illuminate\Http\Request;
+use SimpleSoftwareIO\QrCode\Facades\QrCode;
+
+class ProductController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = Product::query();
+        if ($request->filled('search')) {
+            $search = $request->input('search');
+            $query->where(fn ($q) => $q->where('sku', 'like', "%{$search}%")->orWhere('name', 'like', "%{$search}%"));
+        }
+        if ($request->boolean('alert_only')) { $query->belowReorderPoint(); }
+        match ($request->input('sort', 'stock_asc')) {
+            'stock_desc' => $query->orderBy('stock_quantity', 'desc'),
+            'name'       => $query->orderBy('name', 'asc'),
+            default      => $query->orderBy('stock_quantity', 'asc'),
+        };
+        return view('products.index', ['products' => $query->paginate(20)]);
+    }
+
+    public function create() { return view('products.create'); }
+
+    public function store(Request $request)
+    {
+        Product::create($request->validate([
+            'sku' => ['required','string','max:100','unique:products'],
+            'name' => ['required','string','max:255'],
+            'description' => ['nullable','string'],
+            'stock_quantity' => ['required','integer','min:0'],
+            'reorder_point'  => ['required','integer','min:0'],
+        ]));
+        return redirect()->route('products.index')->with('success', '商品を登録しました');
+    }
+
+    public function show(Product $product)
+    {
+        return view('products.show', [
+            'product' => $product,
+            'transactions' => $product->stockTransactions()->latest()->paginate(50),
+        ]);
+    }
+
+    public function edit(Product $product) { return view('products.edit', compact('product')); }
+
+    public function update(Request $request, Product $product)
+    {
+        $product->update($request->validate([
+            'sku' => ['required','string','max:100','unique:products,sku,'.$product->id],
+            'name' => ['required','string','max:255'],
+            'description' => ['nullable','string'],
+            'reorder_point' => ['required','integer','min:0'],
+        ]));
+        return redirect()->route('products.index')->with('success', '商品情報を更新しました');
+    }
+
+    public function destroy(Product $product)
+    {
+        $product->delete();
+        return redirect()->route('products.index')->with('success', '商品を削除しました');
+    }
+
+    public function qrcode(Product $product)
+    {
+        $svg = QrCode::format('svg')->size(200)->errorCorrection('M')->generate(route('products.show', $product));
+        return response($svg, 200)->header('Content-Type', 'image/svg+xml');
+    }
+
+    public function qrcodeDownload(Product $product)
+    {
+        $png = QrCode::format('png')->size(300)->errorCorrection('M')->generate(route('products.show', $product));
+        return response($png, 200)
+            ->header('Content-Type', 'image/png')
+            ->header('Content-Disposition', 'attachment; filename="qrcode_' . $product->sku . '.png"');
+    }
+
+    public function qrcodeSvgDownload(Product $product)
+    {
+        $svg = QrCode::format('svg')->size(300)->errorCorrection('M')->generate(route('products.show', $product));
+        return response($svg, 200)
+            ->header('Content-Type', 'image/svg+xml')
+            ->header('Content-Disposition', 'attachment; filename="qrcode_' . $product->sku . '.svg"');
+    }
+}

--- a/resources/views/products/show.blade.php
+++ b/resources/views/products/show.blade.php
@@ -1,0 +1,88 @@
+@extends('layouts.app')
+@section('title', $product->name . ' - 商品詳細')
+@section('content')
+<div class="d-flex justify-content-between align-items-center mt-4 mb-3">
+    <h2><i class="bi bi-box-seam me-2"></i>{{ $product->name }}</h2>
+    <div class="d-flex gap-2">
+        <a href="{{ route('products.edit', $product) }}" class="btn btn-outline-secondary"><i class="bi bi-pencil me-1"></i>編集</a>
+        <a href="{{ route('products.index') }}" class="btn btn-outline-secondary"><i class="bi bi-arrow-left me-1"></i>一覧へ</a>
+    </div>
+</div>
+<div class="row g-4">
+    <div class="col-md-4">
+        <div class="card mb-4">
+            <div class="card-header fw-semibold"><i class="bi bi-info-circle me-1"></i>商品情報</div>
+            <div class="card-body">
+                <dl class="row mb-0">
+                    <dt class="col-5 text-muted">SKU</dt><dd class="col-7"><code>{{ $product->sku }}</code></dd>
+                    <dt class="col-5 text-muted">商品名</dt><dd class="col-7">{{ $product->name }}</dd>
+                    <dt class="col-5 text-muted">在庫数</dt>
+                    <dd class="col-7"><span class="fs-5 fw-bold {{ $product->isOutOfStock() ? 'text-danger' : 'text-success' }}">{{ number_format($product->stock_quantity) }}</span></dd>
+                    <dt class="col-5 text-muted">発注点</dt><dd class="col-7">{{ number_format($product->reorder_point) }}</dd>
+                </dl>
+            </div>
+        </div>
+        <div class="card" id="qrcode">
+            <div class="card-header fw-semibold"><i class="bi bi-qr-code me-1"></i>QRコード</div>
+            <div class="card-body text-center">
+                <div class="d-inline-block border rounded p-2 bg-white">
+                    <img src="{{ route('products.qrcode', $product) }}" alt="QR" width="200" height="200">
+                </div>
+                <p class="text-muted small mt-2 mb-3"><code>{{ $product->sku }}</code></p>
+                <div class="d-flex gap-2 justify-content-center flex-wrap">
+                    <a href="{{ route('products.qrcode.download', $product) }}" class="btn btn-outline-primary btn-sm">
+                        <i class="bi bi-download me-1"></i>PNG
+                    </a>
+                    <a href="{{ route('products.qrcode.download.svg', $product) }}" class="btn btn-outline-secondary btn-sm">
+                        <i class="bi bi-file-code me-1"></i>SVG
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-8">
+        <div class="card mb-4">
+            <div class="card-header fw-semibold"><i class="bi bi-arrow-left-right me-1"></i>在庫操作</div>
+            <div class="card-body">
+                @if($errors->any())<div class="alert alert-danger">@foreach($errors->all() as $e)<div>{{ $e }}</div>@endforeach</div>@endif
+                <form method="POST" action="{{ route('stock-transactions.store', $product) }}">
+                    @csrf
+                    <div class="row g-3">
+                        <div class="col-md-4"><label class="form-label fw-semibold">操作種別</label>
+                            <select name="type" class="form-select" required>
+                                <option value="IN">入庫</option><option value="OUT">出庫</option><option value="ADJUST">在庫調整</option>
+                            </select></div>
+                        <div class="col-md-3"><label class="form-label fw-semibold">数量</label>
+                            <input type="number" name="quantity" class="form-control" min="1" value="1" required></div>
+                        <div class="col-md-5"><label class="form-label fw-semibold">理由・メモ</label>
+                            <input type="text" name="reason" class="form-control" placeholder="任意"></div>
+                        <div class="col-12"><button type="submit" class="btn btn-primary"><i class="bi bi-check2 me-1"></i>実行</button></div>
+                    </div>
+                </form>
+            </div>
+        </div>
+        <div class="card">
+            <div class="card-header fw-semibold"><i class="bi bi-clock-history me-1"></i>在庫履歴</div>
+            <div class="card-body p-0">
+                <table class="table table-sm mb-0">
+                    <thead><tr><th>日時</th><th>種別</th><th class="text-end">数量</th><th>理由</th></tr></thead>
+                    <tbody>
+                        @forelse($transactions as $tx)
+                        <tr>
+                            <td class="text-muted small">{{ $tx->created_at->format('Y/m/d H:i') }}</td>
+                            <td>@if($tx->type->value==='IN')<span class="badge bg-success">入庫</span>
+                                @elseif($tx->type->value==='OUT')<span class="badge bg-danger">出庫</span>
+                                @else<span class="badge bg-secondary">調整</span>@endif</td>
+                            <td class="text-end fw-semibold">{{ number_format($tx->quantity) }}</td>
+                            <td class="text-muted small">{{ $tx->reason ?? '-' }}</td>
+                        </tr>
+                        @empty<tr><td colspan="4" class="text-center text-muted py-3">履歴がありません</td></tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+            @if($transactions->hasPages())<div class="card-footer">{{ $transactions->links() }}</div>@endif
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,88 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AccommodationController;
+use App\Http\Controllers\RoomController;
+use App\Http\Controllers\CustomerController;
+use App\Http\Controllers\ReservationController;
+use App\Http\Controllers\PaymentController;
+use App\Http\Controllers\ReviewController;
+use App\Http\Controllers\ReportController;
+use App\Http\Controllers\ProductController;
+use App\Http\Controllers\StockTransactionController;
+use App\Http\Controllers\ElectionController;
+use App\Http\Controllers\TravelController;
+use App\Http\Controllers\EventController;
+
+Route::get('/', fn () => view('welcome'));
+
+Route::middleware('auth')->group(function () {
+    Route::resource('accommodations', AccommodationController::class);
+    Route::resource('rooms', RoomController::class);
+    Route::resource('customers', CustomerController::class);
+    Route::resource('reservations', ReservationController::class);
+    Route::resource('payments', PaymentController::class);
+    Route::resource('reviews', ReviewController::class);
+
+    // ===== 在庫管理 =====
+    Route::resource('products', ProductController::class);
+    Route::get('/products/{product}/qrcode', [ProductController::class, 'qrcode'])->name('products.qrcode');
+    Route::get('/products/{product}/qrcode/download', [ProductController::class, 'qrcodeDownload'])->name('products.qrcode.download');
+    Route::get('/products/{product}/qrcode/download/svg', [ProductController::class, 'qrcodeSvgDownload'])->name('products.qrcode.download.svg');
+    Route::post('/products/{product}/stock-transactions', [StockTransactionController::class, 'store'])->name('stock-transactions.store');
+    Route::get('/stock-transactions', [StockTransactionController::class, 'index'])->name('stock-transactions.index');
+
+    Route::post('/payments/{payment}/process', [PaymentController::class, 'process'])->name('payments.process');
+    Route::post('/payments/{payment}/refund', [PaymentController::class, 'refund'])->name('payments.refund');
+    Route::post('/payments/{payment}/cancel', [PaymentController::class, 'cancel'])->name('payments.cancel');
+    Route::post('/reviews/{review}/helpful', [ReviewController::class, 'addHelpfulVote'])->name('reviews.helpful');
+    Route::post('/reviews/{review}/admin-response', [ReviewController::class, 'addAdminResponse'])->name('reviews.admin-response');
+});
+
+Route::middleware('auth')->group(function () {
+    Route::get('/reports/dashboard', [ReportController::class, 'dashboard'])->name('reports.dashboard');
+    Route::get('/reports/reservations', [ReportController::class, 'reservations'])->name('reports.reservations');
+    Route::get('/reports/revenue', [ReportController::class, 'revenue'])->name('reports.revenue');
+    Route::get('/reports/occupancy', [ReportController::class, 'occupancy'])->name('reports.occupancy');
+    Route::get('/reports/reviews', [ReportController::class, 'reviews'])->name('reports.reviews');
+    Route::get('/reports/customers', [ReportController::class, 'customers'])->name('reports.customers');
+    Route::get('/reports/export', [ReportController::class, 'export'])->name('reports.export');
+});
+
+Route::get('/travel', [TravelController::class, 'index'])->name('travel.index');
+Route::get('/travel/search', [TravelController::class, 'search'])->name('travel.search');
+Route::get('/travel/suggest', [TravelController::class, 'suggest'])->name('travel.suggest');
+Route::get('/travel/accommodations/{id}', [TravelController::class, 'show'])->name('travel.show');
+Route::get('/travel/accommodations/{id}/plans', [TravelController::class, 'searchPlans'])->name('travel.plans');
+Route::get('/travel/accommodations/{id}/reviews', [TravelController::class, 'reviews'])->name('travel.reviews');
+Route::get('/travel/booking/{plan}', [TravelController::class, 'booking'])->name('travel.booking');
+Route::post('/travel/booking/confirm', [TravelController::class, 'confirmBooking'])->name('travel.booking.confirm');
+Route::post('/travel/booking/complete', [TravelController::class, 'completeBooking'])->name('travel.booking.complete');
+Route::post('/travel/favorites', [TravelController::class, 'addFavorite'])->name('travel.favorites.add');
+Route::delete('/travel/favorites/{accommodation}', [TravelController::class, 'removeFavorite'])->name('travel.favorites.remove');
+Route::get('/travel/areas', [TravelController::class, 'areas'])->name('travel.areas');
+Route::get('/events', [EventController::class, 'index'])->name('events.index');
+Route::get('/events/search', [EventController::class, 'search'])->name('events.search');
+Route::get('/events/calendar', [EventController::class, 'calendar'])->name('events.calendar');
+Route::get('/events/{id}', [EventController::class, 'show'])->name('events.show');
+Route::get('/events/my/favorites', [EventController::class, 'favorites'])->name('events.favorites');
+Route::post('/events/favorites', [EventController::class, 'addFavorite'])->name('events.favorites.add');
+Route::delete('/events/favorites/{eventId}', [EventController::class, 'removeFavorite'])->name('events.favorites.remove');
+Route::get('/api/events/search', [EventController::class, 'apiSearch'])->name('events.api.search');
+Route::get('/elections/dashboard', [ElectionController::class, 'dashboard'])->name('elections.dashboard');
+Route::get('/elections', [ElectionController::class, 'index'])->name('elections.index');
+Route::post('/elections', [ElectionController::class, 'store'])->name('elections.store');
+Route::get('/elections/{election}', [ElectionController::class, 'show'])->name('elections.show');
+Route::post('/elections/{election}/predict', [ElectionController::class, 'predict'])->name('elections.predict');
+Route::get('/elections/{election}/predictions', [ElectionController::class, 'getPredictions'])->name('elections.predictions');
+Route::get('/elections/{election}/validate-accuracy', [ElectionController::class, 'validateAccuracy'])->name('elections.validate-accuracy');
+Route::get('/elections-compare', [ElectionController::class, 'compare'])->name('elections.compare');
+Route::post('/elections/{election}/results', [ElectionController::class, 'storeResult'])->name('elections.results.store');
+Route::get('/poll-data', [ElectionController::class, 'pollData'])->name('poll-data.index');
+Route::post('/poll-data', [ElectionController::class, 'storePollData'])->name('poll-data.store');
+Route::get('/parties', [ElectionController::class, 'parties'])->name('parties.index');
+Route::post('/parties', [ElectionController::class, 'storeParty'])->name('parties.store');
+Route::get('/parties/{party}/trend', [ElectionController::class, 'partyTrend'])->name('parties.trend');
+Route::get('/election-districts', [ElectionController::class, 'districts'])->name('districts.index');
+Route::post('/elections/import-csv', [ElectionController::class, 'importCsv'])->name('elections.import-csv');
+Route::get('/elections/{election}/export', [ElectionController::class, 'exportReport'])->name('elections.export');


### PR DESCRIPTION
## Summary

- `ProductController::qrcodeSvgDownload()` — generates 300px SVG QR code and streams it as an attachment with filename `qrcode_{sku}.svg`
- `routes/web.php` — adds `GET /products/{product}/qrcode/download/svg` inside auth group
- `products/show.blade.php` — replaces single PNG button with side-by-side PNG + SVG download buttons (`d-flex gap-2`)

## Test plan

- [ ] Open a product detail page and click "SVGダウンロード" — verify `.svg` file downloads
- [ ] Open downloaded SVG in a browser/editor and confirm QR is scannable
- [ ] Verify existing PNG download still works


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjEM2ZSQARW5aVzEA72VJN)_