### PR TITLE
feat: add product search autocomplete suggestions

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Product;
+use Illuminate\Http\Request;
+use SimpleSoftwareIO\QrCode\Facades\QrCode;
+
+class ProductController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = Product::query();
+        if ($request->filled('search')) {
+            $search = $request->input('search');
+            $query->where(fn ($q) => $q->where('sku', 'like', "%{$search}%")->orWhere('name', 'like', "%{$search}%"));
+        }
+        if ($request->boolean('alert_only')) { $query->belowReorderPoint(); }
+        match ($request->input('sort', 'stock_asc')) {
+            'stock_desc' => $query->orderBy('stock_quantity', 'desc'),
+            'name'       => $query->orderBy('name', 'asc'),
+            default      => $query->orderBy('stock_quantity', 'asc'),
+        };
+        return view('products.index', ['products' => $query->paginate(20)]);
+    }
+
+    public function create() { return view('products.create'); }
+
+    public function store(Request $request)
+    {
+        Product::create($request->validate([
+            'sku' => ['required','string','max:100','unique:products'],
+            'name' => ['required','string','max:255'],
+            'description' => ['nullable','string'],
+            'stock_quantity' => ['required','integer','min:0'],
+            'reorder_point'  => ['required','integer','min:0'],
+        ]));
+        return redirect()->route('products.index')->with('success', '商品を登録しました');
+    }
+
+    public function show(Product $product)
+    {
+        return view('products.show', [
+            'product' => $product,
+            'transactions' => $product->stockTransactions()->latest()->paginate(50),
+        ]);
+    }
+
+    public function edit(Product $product) { return view('products.edit', compact('product')); }
+
+    public function update(Request $request, Product $product)
+    {
+        $product->update($request->validate([
+            'sku' => ['required','string','max:100','unique:products,sku,'.$product->id],
+            'name' => ['required','string','max:255'],
+            'description' => ['nullable','string'],
+            'reorder_point' => ['required','integer','min:0'],
+        ]));
+        return redirect()->route('products.index')->with('success', '商品情報を更新しました');
+    }
+
+    public function destroy(Product $product)
+    {
+        $product->delete();
+        return redirect()->route('products.index')->with('success', '商品を削除しました');
+    }
+
+    public function qrcode(Product $product)
+    {
+        $svg = QrCode::format('svg')->size(200)->errorCorrection('M')->generate(route('products.show', $product));
+        return response($svg, 200)->header('Content-Type', 'image/svg+xml');
+    }
+
+    public function qrcodeDownload(Product $product)
+    {
+        $png = QrCode::format('png')->size(300)->errorCorrection('M')->generate(route('products.show', $product));
+        return response($png, 200)
+            ->header('Content-Type', 'image/png')
+            ->header('Content-Disposition', 'attachment; filename="qrcode_' . $product->sku . '.png"');
+    }
+
+    public function suggest(Request $request)
+    {
+        $q = $request->input('q', '');
+        if (mb_strlen($q) < 1) {
+            return response()->json([]);
+        }
+
+        $products = Product::where(function ($query) use ($q) {
+                $query->where('sku', 'like', "%{$q}%")
+                      ->orWhere('name', 'like', "%{$q}%");
+            })
+            ->orderBy('name')
+            ->limit(10)
+            ->get(['id', 'sku', 'name']);
+
+        return response()->json($products);
+    }
+}

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -1,0 +1,97 @@
+@extends('layouts.app')
+@section('title', '商品一覧 - 在庫管理')
+@section('content')
+<div class="d-flex justify-content-between align-items-center mt-4 mb-3">
+    <h2><i class="bi bi-box-seam me-2"></i>商品一覧</h2>
+    <a href="{{ route('products.create') }}" class="btn btn-primary"><i class="bi bi-plus-circle me-1"></i>商品登録</a>
+</div>
+<div class="card mb-4">
+    <div class="card-body">
+        <form method="GET" action="{{ route('products.index') }}" class="row g-2 align-items-end">
+            <div class="col-md-5">
+                <label class="form-label fw-semibold">検索</label>
+                <input type="text" name="search" id="searchInput" class="form-control"
+                    placeholder="SKU・商品名で検索" value="{{ request('search') }}"
+                    autocomplete="off" list="productSuggestions">
+                <datalist id="productSuggestions"></datalist>
+            </div>
+            <div class="col-md-3">
+                <label class="form-label fw-semibold">並び替え</label>
+                <select name="sort" class="form-select">
+                    <option value="stock_asc" @selected(request('sort','stock_asc')==='stock_asc')>在庫が少ない順</option>
+                    <option value="stock_desc" @selected(request('sort')==='stock_desc')>在庫が多い順</option>
+                    <option value="name" @selected(request('sort')==='name')>商品名順</option>
+                </select>
+            </div>
+            <div class="col-md-2">
+                <div class="form-check mt-4">
+                    <input class="form-check-input" type="checkbox" name="alert_only" value="1" id="alertOnly" @checked(request('alert_only'))>
+                    <label class="form-check-label" for="alertOnly">アラートのみ</label>
+                </div>
+            </div>
+            <div class="col-md-2 d-flex gap-2">
+                <button type="submit" class="btn btn-primary w-100"><i class="bi bi-search"></i></button>
+                <a href="{{ route('products.index') }}" class="btn btn-secondary w-100"><i class="bi bi-x-lg"></i></a>
+            </div>
+        </form>
+    </div>
+</div>
+<div class="card">
+    <div class="card-body p-0">
+        <table class="table table-hover mb-0">
+            <thead>
+                <tr><th>SKU</th><th>商品名</th><th class="text-end">在庫数</th><th class="text-end">発注点</th><th class="text-center">ステータス</th><th class="text-center">QR</th><th class="text-center">操作</th></tr>
+            </thead>
+            <tbody>
+                @forelse($products as $product)
+                <tr class="{{ $product->isBelowReorderPoint() ? 'table-warning' : '' }}">
+                    <td><code>{{ $product->sku }}</code></td>
+                    <td><a href="{{ route('products.show', $product) }}" class="text-decoration-none fw-semibold">{{ $product->name }}</a></td>
+                    <td class="text-end fw-bold {{ $product->isOutOfStock() ? 'text-danger' : '' }}">{{ number_format($product->stock_quantity) }}</td>
+                    <td class="text-end text-muted">{{ number_format($product->reorder_point) }}</td>
+                    <td class="text-center">
+                        @if($product->isOutOfStock()) <span class="badge bg-danger">在庫切れ</span>
+                        @elseif($product->isBelowReorderPoint()) <span class="badge bg-warning text-dark">要発注</span>
+                        @else <span class="badge bg-success">正常</span> @endif
+                    </td>
+                    <td class="text-center">
+                        <a href="{{ route('products.show', $product) }}#qrcode" class="btn btn-sm btn-outline-secondary"><i class="bi bi-qr-code"></i></a>
+                        <a href="{{ route('products.qrcode.download', $product) }}" class="btn btn-sm btn-outline-secondary"><i class="bi bi-download"></i></a>
+                    </td>
+                    <td class="text-center">
+                        <a href="{{ route('products.show', $product) }}" class="btn btn-sm btn-outline-primary"><i class="bi bi-eye"></i></a>
+                        <a href="{{ route('products.edit', $product) }}" class="btn btn-sm btn-outline-secondary"><i class="bi bi-pencil"></i></a>
+                        <form method="POST" action="{{ route('products.destroy', $product) }}" class="d-inline" onsubmit="return confirm('削除しますか？')">
+                            @csrf @method('DELETE')
+                            <button type="submit" class="btn btn-sm btn-outline-danger"><i class="bi bi-trash"></i></button>
+                        </form>
+                    </td>
+                </tr>
+                @empty
+                <tr><td colspan="7" class="text-center text-muted py-4">商品が登録されていません</td></tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+</div>
+<div class="mt-3">{{ $products->withQueryString()->links() }}</div>
+@endsection
+@push('scripts')
+<script>
+const input = document.getElementById('searchInput');
+const list  = document.getElementById('productSuggestions');
+let timer;
+input.addEventListener('input', function () {
+    clearTimeout(timer);
+    const q = this.value.trim();
+    if (q.length < 1) { list.innerHTML = ''; return; }
+    timer = setTimeout(async () => {
+        const res = await fetch('{{ route('products.suggest') }}?q=' + encodeURIComponent(q), {
+            headers: { 'X-Requested-With': 'XMLHttpRequest' }
+        });
+        const items = await res.json();
+        list.innerHTML = items.map(p => `<option value="${p.name}">${p.sku}</option>`).join('');
+    }, 200);
+});
+</script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,88 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AccommodationController;
+use App\Http\Controllers\RoomController;
+use App\Http\Controllers\CustomerController;
+use App\Http\Controllers\ReservationController;
+use App\Http\Controllers\PaymentController;
+use App\Http\Controllers\ReviewController;
+use App\Http\Controllers\ReportController;
+use App\Http\Controllers\ProductController;
+use App\Http\Controllers\StockTransactionController;
+use App\Http\Controllers\ElectionController;
+use App\Http\Controllers\TravelController;
+use App\Http\Controllers\EventController;
+
+Route::get('/', fn () => view('welcome'));
+
+Route::middleware('auth')->group(function () {
+    Route::resource('accommodations', AccommodationController::class);
+    Route::resource('rooms', RoomController::class);
+    Route::resource('customers', CustomerController::class);
+    Route::resource('reservations', ReservationController::class);
+    Route::resource('payments', PaymentController::class);
+    Route::resource('reviews', ReviewController::class);
+
+    // ===== 在庫管理 =====
+    Route::get('/products/suggest', [ProductController::class, 'suggest'])->name('products.suggest');
+    Route::resource('products', ProductController::class);
+    Route::get('/products/{product}/qrcode', [ProductController::class, 'qrcode'])->name('products.qrcode');
+    Route::get('/products/{product}/qrcode/download', [ProductController::class, 'qrcodeDownload'])->name('products.qrcode.download');
+    Route::post('/products/{product}/stock-transactions', [StockTransactionController::class, 'store'])->name('stock-transactions.store');
+    Route::get('/stock-transactions', [StockTransactionController::class, 'index'])->name('stock-transactions.index');
+
+    Route::post('/payments/{payment}/process', [PaymentController::class, 'process'])->name('payments.process');
+    Route::post('/payments/{payment}/refund', [PaymentController::class, 'refund'])->name('payments.refund');
+    Route::post('/payments/{payment}/cancel', [PaymentController::class, 'cancel'])->name('payments.cancel');
+    Route::post('/reviews/{review}/helpful', [ReviewController::class, 'addHelpfulVote'])->name('reviews.helpful');
+    Route::post('/reviews/{review}/admin-response', [ReviewController::class, 'addAdminResponse'])->name('reviews.admin-response');
+});
+
+Route::middleware('auth')->group(function () {
+    Route::get('/reports/dashboard', [ReportController::class, 'dashboard'])->name('reports.dashboard');
+    Route::get('/reports/reservations', [ReportController::class, 'reservations'])->name('reports.reservations');
+    Route::get('/reports/revenue', [ReportController::class, 'revenue'])->name('reports.revenue');
+    Route::get('/reports/occupancy', [ReportController::class, 'occupancy'])->name('reports.occupancy');
+    Route::get('/reports/reviews', [ReportController::class, 'reviews'])->name('reports.reviews');
+    Route::get('/reports/customers', [ReportController::class, 'customers'])->name('reports.customers');
+    Route::get('/reports/export', [ReportController::class, 'export'])->name('reports.export');
+});
+
+Route::get('/travel', [TravelController::class, 'index'])->name('travel.index');
+Route::get('/travel/search', [TravelController::class, 'search'])->name('travel.search');
+Route::get('/travel/suggest', [TravelController::class, 'suggest'])->name('travel.suggest');
+Route::get('/travel/accommodations/{id}', [TravelController::class, 'show'])->name('travel.show');
+Route::get('/travel/accommodations/{id}/plans', [TravelController::class, 'searchPlans'])->name('travel.plans');
+Route::get('/travel/accommodations/{id}/reviews', [TravelController::class, 'reviews'])->name('travel.reviews');
+Route::get('/travel/booking/{plan}', [TravelController::class, 'booking'])->name('travel.booking');
+Route::post('/travel/booking/confirm', [TravelController::class, 'confirmBooking'])->name('travel.booking.confirm');
+Route::post('/travel/booking/complete', [TravelController::class, 'completeBooking'])->name('travel.booking.complete');
+Route::post('/travel/favorites', [TravelController::class, 'addFavorite'])->name('travel.favorites.add');
+Route::delete('/travel/favorites/{accommodation}', [TravelController::class, 'removeFavorite'])->name('travel.favorites.remove');
+Route::get('/travel/areas', [TravelController::class, 'areas'])->name('travel.areas');
+Route::get('/events', [EventController::class, 'index'])->name('events.index');
+Route::get('/events/search', [EventController::class, 'search'])->name('events.search');
+Route::get('/events/calendar', [EventController::class, 'calendar'])->name('events.calendar');
+Route::get('/events/{id}', [EventController::class, 'show'])->name('events.show');
+Route::get('/events/my/favorites', [EventController::class, 'favorites'])->name('events.favorites');
+Route::post('/events/favorites', [EventController::class, 'addFavorite'])->name('events.favorites.add');
+Route::delete('/events/favorites/{eventId}', [EventController::class, 'removeFavorite'])->name('events.favorites.remove');
+Route::get('/api/events/search', [EventController::class, 'apiSearch'])->name('events.api.search');
+Route::get('/elections/dashboard', [ElectionController::class, 'dashboard'])->name('elections.dashboard');
+Route::get('/elections', [ElectionController::class, 'index'])->name('elections.index');
+Route::post('/elections', [ElectionController::class, 'store'])->name('elections.store');
+Route::get('/elections/{election}', [ElectionController::class, 'show'])->name('elections.show');
+Route::post('/elections/{election}/predict', [ElectionController::class, 'predict'])->name('elections.predict');
+Route::get('/elections/{election}/predictions', [ElectionController::class, 'getPredictions'])->name('elections.predictions');
+Route::get('/elections/{election}/validate-accuracy', [ElectionController::class, 'validateAccuracy'])->name('elections.validate-accuracy');
+Route::get('/elections-compare', [ElectionController::class, 'compare'])->name('elections.compare');
+Route::post('/elections/{election}/results', [ElectionController::class, 'storeResult'])->name('elections.results.store');
+Route::get('/poll-data', [ElectionController::class, 'pollData'])->name('poll-data.index');
+Route::post('/poll-data', [ElectionController::class, 'storePollData'])->name('poll-data.store');
+Route::get('/parties', [ElectionController::class, 'parties'])->name('parties.index');
+Route::post('/parties', [ElectionController::class, 'storeParty'])->name('parties.store');
+Route::get('/parties/{party}/trend', [ElectionController::class, 'partyTrend'])->name('parties.trend');
+Route::get('/election-districts', [ElectionController::class, 'districts'])->name('districts.index');
+Route::post('/elections/import-csv', [ElectionController::class, 'importCsv'])->name('elections.import-csv');
+Route::get('/elections/{election}/export', [ElectionController::class, 'exportReport'])->name('elections.export');


### PR DESCRIPTION
## Summary

- `ProductController::suggest()` — accepts `q` (min 1 char), LIKE-searches sku/name, returns up to 10 results as `[{id, sku, name}]`
- `routes/web.php` — adds `GET /products/suggest` **before** `Route::resource('products', ...)` to avoid wildcard conflict
- `products/index.blade.php` — adds `<datalist id="productSuggestions">` + 200ms debounce fetch JS that populates options as user types

## Test plan

- [ ] Type in the search box on the products list — dropdown suggestions appear after 200ms
- [ ] Select a suggestion and submit — list filters correctly
- [ ] Confirm `/products/suggest?q=test` returns JSON (not a 404 from resource route)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjEM2ZSQARW5aVzEA72VJN)_