### PR TITLE
feat: bulk stock-in form for multiple products at once

### DIFF
--- a/app/Http/Controllers/StockTransactionController.php
+++ b/app/Http/Controllers/StockTransactionController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\StockTransactionType;
+use App\Http\Requests\StockOperationRequest;
+use App\Models\Product;
+use App\Services\StockService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class StockTransactionController extends Controller
+{
+    public function __construct(private StockService $stockService) {}
+
+    public function store(StockOperationRequest $request, Product $product)
+    {
+        try {
+            $type     = StockTransactionType::from($request->input('type'));
+            $quantity = $request->integer('quantity');
+            $reason   = $request->input('reason');
+
+            match ($type) {
+                StockTransactionType::IN     => $this->stockService->stockIn($product, $quantity, $reason),
+                StockTransactionType::OUT    => $this->stockService->stockOut($product, $quantity, $reason),
+                StockTransactionType::ADJUST => $this->stockService->adjust($product, $quantity, $reason),
+            };
+
+            return redirect()->route('products.show', $product)->with('success', "{$type->label()}処理が完了しました");
+        } catch (\InvalidArgumentException $e) {
+            return back()->withErrors(['quantity' => $e->getMessage()])->withInput();
+        } catch (\Exception $e) {
+            Log::error('Stock operation failed', ['product_id' => $product->id, 'error' => $e->getMessage()]);
+            return back()->withErrors(['error' => '在庫操作に失敗しました'])->withInput();
+        }
+    }
+
+    public function index(Request $request)
+    {
+        $query = \App\Models\StockTransaction::query()->with('product');
+        if ($request->filled('type'))       { $query->where('type', $request->input('type')); }
+        if ($request->filled('product_id')) { $query->where('product_id', $request->integer('product_id')); }
+        return view('stock-transactions.index', ['transactions' => $query->latest()->paginate(50)]);
+    }
+
+    public function bulk()
+    {
+        $products = Product::orderBy('name')->get(['id', 'sku', 'name', 'stock_quantity']);
+        return view('stock-transactions.bulk', compact('products'));
+    }
+
+    public function bulkStore(Request $request)
+    {
+        $entries = $request->input('entries', []);
+        $count   = 0;
+
+        foreach ($entries as $entry) {
+            if (empty($entry['product_id']) || empty($entry['quantity']) || (int) $entry['quantity'] <= 0) {
+                continue;
+            }
+            $product = Product::find((int) $entry['product_id']);
+            if (!$product) { continue; }
+
+            $this->stockService->stockIn(
+                $product,
+                (int) $entry['quantity'],
+                $entry['reason'] ?? '一括入庫'
+            );
+            $count++;
+        }
+
+        return redirect()
+            ->route('stock-transactions.index')
+            ->with('success', "{$count}件の商品を入庫しました");
+    }
+}

--- a/resources/views/stock-transactions/bulk.blade.php
+++ b/resources/views/stock-transactions/bulk.blade.php
@@ -1,0 +1,58 @@
+@extends('layouts.app')
+@section('title', '一括入庫')
+@section('content')
+<div class="mt-4">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2><i class="bi bi-box-arrow-in-down me-2"></i>一括入庫</h2>
+        <a href="{{ route('stock-transactions.index') }}" class="btn btn-outline-secondary">
+            <i class="bi bi-arrow-left me-1"></i>履歴一覧
+        </a>
+    </div>
+
+    <div class="card">
+        <div class="card-body">
+            <p class="text-muted small mb-3">入庫数量を入力した行だけ登録されます。数量が空または0の行はスキップされます。</p>
+            <form method="POST" action="{{ route('stock-transactions.bulk.store') }}">
+                @csrf
+                <table class="table table-sm table-hover">
+                    <thead class="table-dark">
+                        <tr>
+                            <th style="width:5%">#</th>
+                            <th>SKU</th>
+                            <th>商品名</th>
+                            <th class="text-end" style="width:12%">現在在庫</th>
+                            <th style="width:15%">入庫数量</th>
+                            <th>理由・メモ</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($products as $i => $product)
+                        <tr>
+                            <td class="text-muted small">{{ $i + 1 }}</td>
+                            <td><code>{{ $product->sku }}</code>
+                                <input type="hidden" name="entries[{{ $i }}][product_id]" value="{{ $product->id }}">
+                            </td>
+                            <td>{{ $product->name }}</td>
+                            <td class="text-end fw-semibold">{{ number_format($product->stock_quantity) }}</td>
+                            <td>
+                                <input type="number" name="entries[{{ $i }}][quantity]"
+                                    class="form-control form-control-sm" min="0" placeholder="0">
+                            </td>
+                            <td>
+                                <input type="text" name="entries[{{ $i }}][reason]"
+                                    class="form-control form-control-sm" placeholder="任意">
+                            </td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+                <div class="mt-3">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-check2-all me-1"></i>一括入庫を登録
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,89 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AccommodationController;
+use App\Http\Controllers\RoomController;
+use App\Http\Controllers\CustomerController;
+use App\Http\Controllers\ReservationController;
+use App\Http\Controllers\PaymentController;
+use App\Http\Controllers\ReviewController;
+use App\Http\Controllers\ReportController;
+use App\Http\Controllers\ProductController;
+use App\Http\Controllers\StockTransactionController;
+use App\Http\Controllers\ElectionController;
+use App\Http\Controllers\TravelController;
+use App\Http\Controllers\EventController;
+
+Route::get('/', fn () => view('welcome'));
+
+Route::middleware('auth')->group(function () {
+    Route::resource('accommodations', AccommodationController::class);
+    Route::resource('rooms', RoomController::class);
+    Route::resource('customers', CustomerController::class);
+    Route::resource('reservations', ReservationController::class);
+    Route::resource('payments', PaymentController::class);
+    Route::resource('reviews', ReviewController::class);
+
+    // ===== 在庫管理 =====
+    Route::resource('products', ProductController::class);
+    Route::get('/products/{product}/qrcode', [ProductController::class, 'qrcode'])->name('products.qrcode');
+    Route::get('/products/{product}/qrcode/download', [ProductController::class, 'qrcodeDownload'])->name('products.qrcode.download');
+    Route::post('/products/{product}/stock-transactions', [StockTransactionController::class, 'store'])->name('stock-transactions.store');
+    Route::get('/stock-transactions', [StockTransactionController::class, 'index'])->name('stock-transactions.index');
+    Route::get('/stock-transactions/bulk', [StockTransactionController::class, 'bulk'])->name('stock-transactions.bulk');
+    Route::post('/stock-transactions/bulk', [StockTransactionController::class, 'bulkStore'])->name('stock-transactions.bulk.store');
+
+    Route::post('/payments/{payment}/process', [PaymentController::class, 'process'])->name('payments.process');
+    Route::post('/payments/{payment}/refund', [PaymentController::class, 'refund'])->name('payments.refund');
+    Route::post('/payments/{payment}/cancel', [PaymentController::class, 'cancel'])->name('payments.cancel');
+    Route::post('/reviews/{review}/helpful', [ReviewController::class, 'addHelpfulVote'])->name('reviews.helpful');
+    Route::post('/reviews/{review}/admin-response', [ReviewController::class, 'addAdminResponse'])->name('reviews.admin-response');
+});
+
+Route::middleware('auth')->group(function () {
+    Route::get('/reports/dashboard', [ReportController::class, 'dashboard'])->name('reports.dashboard');
+    Route::get('/reports/reservations', [ReportController::class, 'reservations'])->name('reports.reservations');
+    Route::get('/reports/revenue', [ReportController::class, 'revenue'])->name('reports.revenue');
+    Route::get('/reports/occupancy', [ReportController::class, 'occupancy'])->name('reports.occupancy');
+    Route::get('/reports/reviews', [ReportController::class, 'reviews'])->name('reports.reviews');
+    Route::get('/reports/customers', [ReportController::class, 'customers'])->name('reports.customers');
+    Route::get('/reports/export', [ReportController::class, 'export'])->name('reports.export');
+});
+
+Route::get('/travel', [TravelController::class, 'index'])->name('travel.index');
+Route::get('/travel/search', [TravelController::class, 'search'])->name('travel.search');
+Route::get('/travel/suggest', [TravelController::class, 'suggest'])->name('travel.suggest');
+Route::get('/travel/accommodations/{id}', [TravelController::class, 'show'])->name('travel.show');
+Route::get('/travel/accommodations/{id}/plans', [TravelController::class, 'searchPlans'])->name('travel.plans');
+Route::get('/travel/accommodations/{id}/reviews', [TravelController::class, 'reviews'])->name('travel.reviews');
+Route::get('/travel/booking/{plan}', [TravelController::class, 'booking'])->name('travel.booking');
+Route::post('/travel/booking/confirm', [TravelController::class, 'confirmBooking'])->name('travel.booking.confirm');
+Route::post('/travel/booking/complete', [TravelController::class, 'completeBooking'])->name('travel.booking.complete');
+Route::post('/travel/favorites', [TravelController::class, 'addFavorite'])->name('travel.favorites.add');
+Route::delete('/travel/favorites/{accommodation}', [TravelController::class, 'removeFavorite'])->name('travel.favorites.remove');
+Route::get('/travel/areas', [TravelController::class, 'areas'])->name('travel.areas');
+Route::get('/events', [EventController::class, 'index'])->name('events.index');
+Route::get('/events/search', [EventController::class, 'search'])->name('events.search');
+Route::get('/events/calendar', [EventController::class, 'calendar'])->name('events.calendar');
+Route::get('/events/{id}', [EventController::class, 'show'])->name('events.show');
+Route::get('/events/my/favorites', [EventController::class, 'favorites'])->name('events.favorites');
+Route::post('/events/favorites', [EventController::class, 'addFavorite'])->name('events.favorites.add');
+Route::delete('/events/favorites/{eventId}', [EventController::class, 'removeFavorite'])->name('events.favorites.remove');
+Route::get('/api/events/search', [EventController::class, 'apiSearch'])->name('events.api.search');
+Route::get('/elections/dashboard', [ElectionController::class, 'dashboard'])->name('elections.dashboard');
+Route::get('/elections', [ElectionController::class, 'index'])->name('elections.index');
+Route::post('/elections', [ElectionController::class, 'store'])->name('elections.store');
+Route::get('/elections/{election}', [ElectionController::class, 'show'])->name('elections.show');
+Route::post('/elections/{election}/predict', [ElectionController::class, 'predict'])->name('elections.predict');
+Route::get('/elections/{election}/predictions', [ElectionController::class, 'getPredictions'])->name('elections.predictions');
+Route::get('/elections/{election}/validate-accuracy', [ElectionController::class, 'validateAccuracy'])->name('elections.validate-accuracy');
+Route::get('/elections-compare', [ElectionController::class, 'compare'])->name('elections.compare');
+Route::post('/elections/{election}/results', [ElectionController::class, 'storeResult'])->name('elections.results.store');
+Route::get('/poll-data', [ElectionController::class, 'pollData'])->name('poll-data.index');
+Route::post('/poll-data', [ElectionController::class, 'storePollData'])->name('poll-data.store');
+Route::get('/parties', [ElectionController::class, 'parties'])->name('parties.index');
+Route::post('/parties', [ElectionController::class, 'storeParty'])->name('parties.store');
+Route::get('/parties/{party}/trend', [ElectionController::class, 'partyTrend'])->name('parties.trend');
+Route::get('/election-districts', [ElectionController::class, 'districts'])->name('districts.index');
+Route::post('/elections/import-csv', [ElectionController::class, 'importCsv'])->name('elections.import-csv');
+Route::get('/elections/{election}/export', [ElectionController::class, 'exportReport'])->name('elections.export');


### PR DESCRIPTION
## Summary

- `StockTransactionController::bulk()` — renders a table listing all products with quantity/reason inputs
- `StockTransactionController::bulkStore()` — iterates `entries[]`, skips rows with empty/zero quantity, calls `stockService->stockIn()`, reports processed count
- `routes/web.php` — adds `GET /stock-transactions/bulk` and `POST /stock-transactions/bulk` before conflicting resource routes
- `stock-transactions/bulk.blade.php` — Bootstrap table form with hidden `product_id`, number input, and reason text per row

## Test plan

- [ ] Navigate to `/stock-transactions/bulk` — all products appear in the table
- [ ] Enter quantities for a subset of rows and submit — only those rows are processed
- [ ] Rows left blank/zero are skipped without error
- [ ] Success message shows correct count of processed rows


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjEM2ZSQARW5aVzEA72VJN)_