### PR TITLE
fix: patch IDOR and missing admin auth in ReviewController

### DIFF
--- a/laravel_project/app/Http/Controllers/ReviewController.php
+++ b/laravel_project/app/Http/Controllers/ReviewController.php
@@ -6,6 +6,7 @@ use App\Models\Review;
 use App\Models\Reservation;
 use App\Models\Accommodation;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
 
 class ReviewController extends Controller
@@ -15,17 +16,23 @@ class ReviewController extends Controller
      */
     public function index(Request $request)
     {
+        $request->validate([
+            'accommodation_id' => 'nullable|integer|exists:accommodations,id',
+            'rating'           => 'nullable|integer|min:1|max:5',
+            'sort'             => 'nullable|in:helpful,rating_high,rating_low,recent',
+        ]);
+
         $query = Review::with(['customer', 'accommodation', 'reservation'])
             ->published();
 
         // 宿泊施設でフィルタ
-        if ($request->has('accommodation_id')) {
-            $query->where('accommodation_id', $request->input('accommodation_id'));
+        if ($request->filled('accommodation_id')) {
+            $query->where('accommodation_id', $request->integer('accommodation_id'));
         }
 
         // 評価でフィルタ
-        if ($request->has('rating')) {
-            $query->withRating($request->input('rating'));
+        if ($request->filled('rating')) {
+            $query->withRating($request->integer('rating'));
         }
 
         // 並び替え
@@ -63,6 +70,11 @@ class ReviewController extends Controller
             $reservation = Reservation::with(['room.accommodation', 'customer'])
                 ->findOrFail($reservationId);
 
+            // 自分の予約のみレビュー可能
+            if ($reservation->customer_id !== auth()->id()) {
+                abort(403);
+            }
+
             // チェックアウト済みかチェック
             if ($reservation->status !== Reservation::STATUS_CHECKED_OUT) {
                 return redirect()->back()
@@ -98,6 +110,11 @@ class ReviewController extends Controller
 
         $reservation = Reservation::with(['room.accommodation', 'customer'])->findOrFail($validated['reservation_id']);
 
+        // 自分の予約のみレビュー可能
+        if ($reservation->customer_id !== auth()->id()) {
+            abort(403);
+        }
+
         // 既にレビュー済みかチェック
         if ($reservation->review()->exists()) {
             return redirect()->back()
@@ -116,8 +133,10 @@ class ReviewController extends Controller
             'amenities_rating' => $validated['amenities_rating'] ?? null,
             'title' => $validated['title'] ?? null,
             'comment' => $validated['comment'] ?? null,
-            'is_verified' => true, // 実際の予約からのレビューなので自動的に認証済み
         ]);
+
+        // 実際の予約からのレビューなので自動的に認証済みにする
+        $review->verify();
 
         return redirect()->route('reviews.show', $review)
             ->with('success', 'レビューを投稿しました。ありがとうございます！');
@@ -205,6 +224,8 @@ class ReviewController extends Controller
      */
     public function addAdminResponse(Review $review, Request $request)
     {
+        Gate::authorize('admin');
+
         $validated = $request->validate([
             'admin_response' => 'required|string|max:1000',
         ]);


### PR DESCRIPTION
## Summary

- **IDOR fix** — `create()` and `store()` now verify the reservation belongs to the authenticated customer (`$reservation->customer_id !== auth()->id()`) before allowing review submission; previously any logged-in user could post reviews against any reservation
- **`is_verified` regression fix** — `is_verified` was silently dropped from `Review::create()` after moving it to `$guarded`; now calls `$review->verify()` explicitly after creation so confirmed-reservation reviews are still auto-verified
- **Missing admin auth** — `addAdminResponse()` now requires `Gate::authorize('admin')`; previously any authenticated user could inject an admin reply on any public review
- **Input validation** — `index()` now validates `accommodation_id` (exists check), `rating` (integer 1–5), and `sort` (enum whitelist); uses `$request->filled()` / `$request->integer()` instead of `has()` / `input()` for safer typed access

## Security Impact

Without these fixes:
1. A customer could POST `reservation_id=<other_customer_reservation_id>` and publish a review as if they stayed there (IDOR)
2. Any logged-in user could POST to the admin-response endpoint and inject arbitrary text as an official admin reply
3. Auto-verification of real-reservation reviews was silently broken by the `$guarded` change in the Review model

## Test plan

- [ ] Attempt to create a review for a reservation belonging to another customer → expect 403
- [ ] Submit a review for your own checked-out reservation → confirm it is created and `is_verified = true`
- [ ] Attempt to call `addAdminResponse` as a non-admin → expect 403
- [ ] Call `addAdminResponse` as an admin → confirm response is saved
- [ ] GET `/reviews?rating=6` → expect 422 validation error
- [ ] GET `/reviews?accommodation_id=99999` → expect 422 (non-existent id)


---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_