### PR TITLE
fix: narrow Customer model mass assignment to protect system-managed fields

### DIFF
--- a/laravel_project/app/Models/Customer.php
+++ b/laravel_project/app/Models/Customer.php
@@ -17,12 +17,15 @@ class Customer extends Model
         'email',
         'phone',
         'address',
-        'last_stay_date',
-        'total_stays',
-        'total_spent',
         'privacy_consent',
         'privacy_consent_date',
         'marketing_consent',
+    ];
+
+    protected $guarded = [
+        'last_stay_date',
+        'total_stays',
+        'total_spent',
         'deletion_requested',
         'deletion_requested_at',
     ];


### PR DESCRIPTION
## Summary

- Remove `last_stay_date`, `total_stays`, `total_spent`, `deletion_requested`, and `deletion_requested_at` from `$fillable` in the `Customer` model
- Add those fields to `$guarded` to prevent mass assignment

## Security Impact

Without this fix:
- A user crafting a raw POST with `total_stays=999` or `total_spent=999999` could artificially inflate their loyalty tier / stay history
- Setting `deletion_requested=false` could silently cancel a previously submitted GDPR erasure request, keeping their data alive
- Setting `deletion_requested=true` on another customer's record (via any endpoint that accepts customer data) could trigger an unintended deletion flag

`updateStayHistory()` and `requestDeletion()` already use direct property assignment + `save()`, so they are completely unaffected by this tightening.

## Test plan

- [ ] POST customer creation with `total_stays=999` → confirm stays remain 0
- [ ] POST customer update with `deletion_requested=false` after requesting deletion → confirm deletion flag is not cleared
- [ ] Confirm `updateStayHistory()` still increments `total_stays` and `total_spent` correctly
- [ ] Confirm `requestDeletion()` still sets `deletion_requested = true`


---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_