### PR TITLE
fix: require admin authorization on all ReportController endpoints

### DIFF
--- a/laravel_project/app/Http/Controllers/ReportController.php
+++ b/laravel_project/app/Http/Controllers/ReportController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Services\ReportService;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 use Carbon\Carbon;
 use Inertia\Inertia;
 
@@ -21,6 +22,8 @@ class ReportController extends Controller
      */
     public function dashboard(Request $request)
     {
+        Gate::authorize('admin');
+
         $request->validate([
             'accommodation_id' => 'nullable|integer|exists:accommodations,id',
         ]);
@@ -39,6 +42,8 @@ class ReportController extends Controller
      */
     public function reservations(Request $request)
     {
+        Gate::authorize('admin');
+
         $request->validate([
             'accommodation_id' => 'nullable|integer|exists:accommodations,id',
             'start_date'       => 'nullable|date',
@@ -62,6 +67,8 @@ class ReportController extends Controller
      */
     public function revenue(Request $request)
     {
+        Gate::authorize('admin');
+
         $request->validate([
             'accommodation_id' => 'nullable|integer|exists:accommodations,id',
             'start_date'       => 'nullable|date',
@@ -85,6 +92,8 @@ class ReportController extends Controller
      */
     public function occupancy(Request $request)
     {
+        Gate::authorize('admin');
+
         $request->validate([
             'accommodation_id' => 'required|integer|exists:accommodations,id',
             'start_date'       => 'nullable|date',
@@ -108,6 +117,8 @@ class ReportController extends Controller
      */
     public function reviews(Request $request)
     {
+        Gate::authorize('admin');
+
         $request->validate([
             'accommodation_id' => 'nullable|integer|exists:accommodations,id',
         ]);
@@ -126,6 +137,8 @@ class ReportController extends Controller
      */
     public function customers(Request $request)
     {
+        Gate::authorize('admin');
+
         $request->validate([
             'accommodation_id' => 'nullable|integer|exists:accommodations,id',
         ]);
@@ -144,6 +157,8 @@ class ReportController extends Controller
      */
     public function export(Request $request)
     {
+        Gate::authorize('admin');
+
         $request->validate([
             'accommodation_id' => 'nullable|integer|exists:accommodations,id',
             'type'             => 'nullable|in:dashboard,reservations,revenue,occupancy,reviews,customers',


### PR DESCRIPTION
## Summary

Add `Gate::authorize('admin')` to all seven methods in `ReportController`: `dashboard()`, `reservations()`, `revenue()`, `occupancy()`, `reviews()`, `customers()`, and `export()`.

## Security Impact

All report endpoints were protected only by `auth` middleware, meaning any authenticated user (ordinary customers, hotel guests) could access:
- Full revenue reports across all properties
- Occupancy rates and booking volumes
- Customer aggregate statistics
- Exportable JSON dumps of all the above

This is a business data confidentiality issue — only system admins should have visibility into cross-property aggregate reporting.

## Test plan

- [ ] Authenticated non-admin user GET `/reports/dashboard` → expect 403
- [ ] Authenticated non-admin user GET `/reports/export` → expect 403
- [ ] Authenticated admin user GET `/reports/dashboard` → expect 200 with data
- [ ] Unauthenticated GET `/reports/revenue` → expect redirect to login (existing `auth` middleware still applies)


---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_