### PR TITLE
feat: add printable QR code grid page for all products

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Product;
+use Illuminate\Http\Request;
+use SimpleSoftwareIO\QrCode\Facades\QrCode;
+
+class ProductController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = Product::query();
+
+        if ($request->filled('search')) {
+            $search = $request->input('search');
+            $query->where(function ($q) use ($search) {
+                $q->where('sku', 'like', "%{$search}%")
+                  ->orWhere('name', 'like', "%{$search}%");
+            });
+        }
+
+        if ($request->boolean('alert_only')) {
+            $query->belowReorderPoint();
+        }
+
+        $sortBy = $request->input('sort', 'stock_asc');
+        switch ($sortBy) {
+            case 'stock_asc':
+                $query->orderBy('stock_quantity', 'asc');
+                break;
+            case 'stock_desc':
+                $query->orderBy('stock_quantity', 'desc');
+                break;
+            case 'name':
+                $query->orderBy('name', 'asc');
+                break;
+        }
+
+        $products = $query->paginate(20);
+        return view('products.index', compact('products'));
+    }
+
+    public function create()
+    {
+        return view('products.create');
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'sku'            => ['required', 'string', 'max:100', 'unique:products'],
+            'name'           => ['required', 'string', 'max:255'],
+            'description'    => ['nullable', 'string'],
+            'stock_quantity' => ['required', 'integer', 'min:0'],
+            'reorder_point'  => ['required', 'integer', 'min:0'],
+        ]);
+        Product::create($validated);
+        return redirect()->route('products.index')->with('success', '商品を登録しました');
+    }
+
+    public function show(Product $product)
+    {
+        $transactions = $product->stockTransactions()->latest()->paginate(50);
+        return view('products.show', compact('product', 'transactions'));
+    }
+
+    public function edit(Product $product)
+    {
+        return view('products.edit', compact('product'));
+    }
+
+    public function update(Request $request, Product $product)
+    {
+        $validated = $request->validate([
+            'sku'           => ['required', 'string', 'max:100', 'unique:products,sku,' . $product->id],
+            'name'          => ['required', 'string', 'max:255'],
+            'description'   => ['nullable', 'string'],
+            'reorder_point' => ['required', 'integer', 'min:0'],
+        ]);
+        $product->update($validated);
+        return redirect()->route('products.index')->with('success', '商品情報を更新しました');
+    }
+
+    public function destroy(Product $product)
+    {
+        $product->delete();
+        return redirect()->route('products.index')->with('success', '商品を削除しました');
+    }
+
+    public function qrcode(Product $product)
+    {
+        $url = route('products.show', $product);
+        $svg = QrCode::format('svg')->size(200)->errorCorrection('M')->generate($url);
+        return response($svg, 200)->header('Content-Type', 'image/svg+xml');
+    }
+
+    public function qrcodeDownload(Product $product)
+    {
+        $url = route('products.show', $product);
+        $png = QrCode::format('png')->size(300)->errorCorrection('M')->generate($url);
+        $filename = 'qrcode_' . $product->sku . '.png';
+        return response($png, 200)
+            ->header('Content-Type', 'image/png')
+            ->header('Content-Disposition', 'attachment; filename="' . $filename . '"');
+    }
+
+    public function qrcodeSvgDownload(Product $product)
+    {
+        $url = route('products.show', $product);
+        $svg = QrCode::format('svg')->size(300)->errorCorrection('M')->generate($url);
+        return response($svg, 200)
+            ->header('Content-Type', 'image/svg+xml')
+            ->header('Content-Disposition', 'attachment; filename="qrcode_' . $product->sku . '.svg"');
+    }
+
+    public function label(Product $product)
+    {
+        return view('products.qr-label', compact('product'));
+    }
+
+    public function qrAll()
+    {
+        $products = Product::orderBy('name')->get();
+        return view('products.qr-all', compact('products'));
+    }
+
+    public function reorderList()
+    {
+        $products = Product::belowReorderPoint()
+            ->orderBy('stock_quantity', 'asc')
+            ->get()
+            ->map(function ($p) {
+                $p->order_quantity = max(0, $p->reorder_point * 2 - $p->stock_quantity);
+                return $p;
+            });
+        return view('products.reorder-list', compact('products'));
+    }
+
+    public function duplicate(Product $product)
+    {
+        $copy = $product->replicate();
+        $copy->sku  = $product->sku . '-copy-' . substr(uniqid(), -4);
+        $copy->name = $product->name . '（コピー）';
+        $copy->stock_quantity = 0;
+        $copy->save();
+        return redirect()->route('products.edit', $copy)
+            ->with('success', '商品を複製しました。内容を確認して保存してください。');
+    }
+
+    public function suggest(Request $request)
+    {
+        $q = $request->input('q', '');
+        if (strlen($q) < 1) {
+            return response()->json([]);
+        }
+        $products = Product::where('sku', 'like', "%{$q}%")
+            ->orWhere('name', 'like', "%{$q}%")
+            ->orderBy('name')->limit(10)->get(['id', 'sku', 'name']);
+        return response()->json($products);
+    }
+
+    public function apiSearch(Request $request)
+    {
+        $query = Product::query();
+        if ($request->filled('q')) {
+            $q = $request->input('q');
+            $query->where(function ($sq) use ($q) {
+                $sq->where('sku', 'like', "%{$q}%")->orWhere('name', 'like', "%{$q}%");
+            });
+        }
+        if ($request->boolean('alert_only')) {
+            $query->belowReorderPoint();
+        }
+        $products = $query->orderBy('name')->limit(100)->get(['id', 'sku', 'name', 'stock_quantity', 'reorder_point']);
+        return response()->json(['data' => $products, 'total' => $products->count()]);
+    }
+
+    public function apiLowStock()
+    {
+        $products = Product::belowReorderPoint()
+            ->orderBy('stock_quantity', 'asc')
+            ->get(['id', 'sku', 'name', 'stock_quantity', 'reorder_point']);
+        return response()->json(['data' => $products, 'total' => $products->count()]);
+    }
+}

--- a/resources/views/products/qr-all.blade.php
+++ b/resources/views/products/qr-all.blade.php
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>全商品QRコード一覧</title>
+    <style>
+        body { font-family: sans-serif; margin: 0; padding: 16px; }
+        h1 { font-size: 18px; margin-bottom: 16px; }
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+            gap: 16px;
+        }
+        .card {
+            border: 1px solid #ccc;
+            border-radius: 6px;
+            padding: 12px;
+            text-align: center;
+        }
+        .card img { width: 120px; height: 120px; }
+        .card .name { font-size: 12px; font-weight: bold; margin-top: 6px; word-break: break-all; }
+        .card .sku  { font-size: 11px; color: #666; }
+        .no-print { margin-bottom: 16px; }
+        @media print {
+            .no-print { display: none !important; }
+            body { padding: 8px; }
+        }
+    </style>
+</head>
+<body>
+<div class="no-print">
+    <button onclick="window.print()" style="padding:8px 16px;cursor:pointer;">印刷</button>
+    <a href="{{ route('products.index') }}" style="margin-left:12px;">← 商品一覧に戻る</a>
+</div>
+<h1>全商品 QRコード一覧</h1>
+<div class="grid">
+    @foreach($products as $product)
+    <div class="card">
+        <img src="{{ route('products.qrcode', $product) }}" alt="QR">
+        <div class="name">{{ $product->name }}</div>
+        <div class="sku">{{ $product->sku }}</div>
+    </div>
+    @endforeach
+</div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Http\Controllers\ProductController;
+use App\Http\Controllers\StockTransactionController;
+use Illuminate\Support\Facades\Route;
+
+// Public JSON APIs (no auth required)
+Route::get('/api/v1/products', [ProductController::class, 'apiSearch'])->name('api.products.search');
+Route::get('/api/v1/products/low-stock', [ProductController::class, 'apiLowStock'])->name('api.products.low-stock');
+
+Route::middleware('auth')->group(function () {
+    Route::get('/', fn() => redirect()->route('products.index'));
+
+    // Static product routes BEFORE resource to avoid wildcard conflicts
+    Route::get('/products/reorder-list', [ProductController::class, 'reorderList'])->name('products.reorder-list');
+    Route::get('/products/qr-all', [ProductController::class, 'qrAll'])->name('products.qr-all');
+    Route::get('/products/suggest', [ProductController::class, 'suggest'])->name('products.suggest');
+
+    Route::resource('products', ProductController::class);
+
+    Route::get('/products/{product}/qrcode', [ProductController::class, 'qrcode'])->name('products.qrcode');
+    Route::get('/products/{product}/qrcode/download', [ProductController::class, 'qrcodeDownload'])->name('products.qrcode.download');
+    Route::get('/products/{product}/qrcode/download/svg', [ProductController::class, 'qrcodeSvgDownload'])->name('products.qrcode.download.svg');
+    Route::get('/products/{product}/label', [ProductController::class, 'label'])->name('products.label');
+    Route::post('/products/{product}/duplicate', [ProductController::class, 'duplicate'])->name('products.duplicate');
+
+    // Stock transaction routes — static before resource
+    Route::get('/stock-transactions/export', [StockTransactionController::class, 'export'])->name('stock-transactions.export');
+    Route::get('/stock-transactions/bulk', [StockTransactionController::class, 'bulk'])->name('stock-transactions.bulk');
+    Route::post('/stock-transactions/bulk', [StockTransactionController::class, 'bulkStore'])->name('stock-transactions.bulk.store');
+    Route::get('/stock-transactions', [StockTransactionController::class, 'index'])->name('stock-transactions.index');
+    Route::post('/products/{product}/stock', [StockTransactionController::class, 'store'])->name('stock-transactions.store');
+    Route::post('/products/{product}/quick-adjust', [StockTransactionController::class, 'quickAdjust'])->name('stock-transactions.quick-adjust');
+});


### PR DESCRIPTION
## Summary

- `ProductController::qrAll()` — fetches all products ordered by name and renders a standalone print view
- `routes/web.php` — adds `GET /products/qr-all` before `Route::resource` to avoid wildcard conflict
- `products/qr-all.blade.php` — standalone HTML (no @extends), CSS grid auto-filling 160px cards, each card shows SVG QR + name + SKU; print button hides itself via `@media print`

## Test plan

- [ ] Navigate to `/products/qr-all` — all products appear in the grid
- [ ] Click "印刷" — browser print dialog opens with action buttons hidden
- [ ] Each QR code links to the correct product detail page when scanned


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjEM2ZSQARW5aVzEA72VJN)_