### PR TITLE
feat: add dedicated stock alert dashboard page

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Product;
+use Illuminate\Http\Request;
+use SimpleSoftwareIO\QrCode\Facades\QrCode;
+
+class ProductController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = Product::query();
+
+        if ($request->filled('search')) {
+            $search = $request->input('search');
+            $query->where(function ($q) use ($search) {
+                $q->where('sku', 'like', "%{$search}%")
+                  ->orWhere('name', 'like', "%{$search}%");
+            });
+        }
+
+        if ($request->boolean('alert_only')) {
+            $query->belowReorderPoint();
+        }
+
+        $sortBy = $request->input('sort', 'stock_asc');
+        switch ($sortBy) {
+            case 'stock_asc': $query->orderBy('stock_quantity', 'asc'); break;
+            case 'stock_desc': $query->orderBy('stock_quantity', 'desc'); break;
+            case 'name': $query->orderBy('name', 'asc'); break;
+        }
+
+        $products = $query->paginate(20);
+        return view('products.index', compact('products'));
+    }
+
+    public function create() { return view('products.create'); }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'sku'            => ['required', 'string', 'max:100', 'unique:products'],
+            'name'           => ['required', 'string', 'max:255'],
+            'description'    => ['nullable', 'string'],
+            'stock_quantity' => ['required', 'integer', 'min:0'],
+            'reorder_point'  => ['required', 'integer', 'min:0'],
+        ]);
+        Product::create($validated);
+        return redirect()->route('products.index')->with('success', '商品を登録しました');
+    }
+
+    public function show(Product $product)
+    {
+        $transactions = $product->stockTransactions()->latest()->paginate(50);
+        return view('products.show', compact('product', 'transactions'));
+    }
+
+    public function edit(Product $product) { return view('products.edit', compact('product')); }
+
+    public function update(Request $request, Product $product)
+    {
+        $validated = $request->validate([
+            'sku'           => ['required', 'string', 'max:100', 'unique:products,sku,' . $product->id],
+            'name'          => ['required', 'string', 'max:255'],
+            'description'   => ['nullable', 'string'],
+            'reorder_point' => ['required', 'integer', 'min:0'],
+        ]);
+        $product->update($validated);
+        return redirect()->route('products.index')->with('success', '商品情報を更新しました');
+    }
+
+    public function destroy(Product $product)
+    {
+        $product->delete();
+        return redirect()->route('products.index')->with('success', '商品を削除しました');
+    }
+
+    public function qrcode(Product $product)
+    {
+        $svg = QrCode::format('svg')->size(200)->errorCorrection('M')->generate(route('products.show', $product));
+        return response($svg, 200)->header('Content-Type', 'image/svg+xml');
+    }
+
+    public function qrcodeDownload(Product $product)
+    {
+        $png = QrCode::format('png')->size(300)->errorCorrection('M')->generate(route('products.show', $product));
+        return response($png, 200)
+            ->header('Content-Type', 'image/png')
+            ->header('Content-Disposition', 'attachment; filename="qrcode_' . $product->sku . '.png"');
+    }
+
+    public function qrcodeSvgDownload(Product $product)
+    {
+        $svg = QrCode::format('svg')->size(300)->errorCorrection('M')->generate(route('products.show', $product));
+        return response($svg, 200)
+            ->header('Content-Type', 'image/svg+xml')
+            ->header('Content-Disposition', 'attachment; filename="qrcode_' . $product->sku . '.svg"');
+    }
+
+    public function label(Product $product) { return view('products.qr-label', compact('product')); }
+
+    public function qrAll()
+    {
+        $products = Product::orderBy('name')->get();
+        return view('products.qr-all', compact('products'));
+    }
+
+    public function alertDashboard()
+    {
+        $alertProducts = Product::belowReorderPoint()
+            ->orderBy('stock_quantity', 'asc')
+            ->get()
+            ->map(function ($p) {
+                $p->deficit = $p->reorder_point - $p->stock_quantity;
+                return $p;
+            });
+
+        $stats = [
+            'alert_count'   => $alertProducts->count(),
+            'total_deficit' => $alertProducts->sum('deficit'),
+            'most_critical' => $alertProducts->first(),
+        ];
+
+        return view('products.alert-dashboard', compact('alertProducts', 'stats'));
+    }
+
+    public function reorderList()
+    {
+        $products = Product::belowReorderPoint()
+            ->orderBy('stock_quantity', 'asc')
+            ->get()
+            ->map(function ($p) {
+                $p->order_quantity = max(0, $p->reorder_point * 2 - $p->stock_quantity);
+                return $p;
+            });
+        return view('products.reorder-list', compact('products'));
+    }
+
+    public function duplicate(Product $product)
+    {
+        $copy = $product->replicate();
+        $copy->sku  = $product->sku . '-copy-' . substr(uniqid(), -4);
+        $copy->name = $product->name . '（コピー）';
+        $copy->stock_quantity = 0;
+        $copy->save();
+        return redirect()->route('products.edit', $copy)->with('success', '商品を複製しました。内容を確認して保存してください。');
+    }
+
+    public function suggest(Request $request)
+    {
+        $q = $request->input('q', '');
+        if (strlen($q) < 1) return response()->json([]);
+        $products = Product::where('sku', 'like', "%{$q}%")
+            ->orWhere('name', 'like', "%{$q}%")
+            ->orderBy('name')->limit(10)->get(['id', 'sku', 'name']);
+        return response()->json($products);
+    }
+
+    public function apiSearch(Request $request)
+    {
+        $query = Product::query();
+        if ($request->filled('q')) {
+            $q = $request->input('q');
+            $query->where(fn($sq) => $sq->where('sku', 'like', "%{$q}%")->orWhere('name', 'like', "%{$q}%"));
+        }
+        if ($request->boolean('alert_only')) $query->belowReorderPoint();
+        $products = $query->orderBy('name')->limit(100)->get(['id', 'sku', 'name', 'stock_quantity', 'reorder_point']);
+        return response()->json(['data' => $products, 'total' => $products->count()]);
+    }
+
+    public function apiLowStock()
+    {
+        $products = Product::belowReorderPoint()
+            ->orderBy('stock_quantity', 'asc')
+            ->get(['id', 'sku', 'name', 'stock_quantity', 'reorder_point']);
+        return response()->json(['data' => $products, 'total' => $products->count()]);
+    }
+}

--- a/resources/views/products/alert-dashboard.blade.php
+++ b/resources/views/products/alert-dashboard.blade.php
@@ -1,0 +1,86 @@
+@extends('layouts.app')
+
+@section('title', '在庫アラートダッシュボード')
+
+@section('content')
+<div class="d-flex justify-content-between align-items-center mt-4 mb-3">
+    <h2><i class="bi bi-exclamation-triangle-fill text-danger me-2"></i>在庫アラートダッシュボード</h2>
+    <div class="d-flex gap-2">
+        <a href="{{ route('products.reorder-list') }}" class="btn btn-outline-secondary">
+            <i class="bi bi-clipboard2-check me-1"></i>発注リスト
+        </a>
+        <a href="{{ route('products.index') }}" class="btn btn-outline-secondary">
+            <i class="bi bi-box-seam me-1"></i>商品一覧
+        </a>
+    </div>
+</div>
+
+<div class="row g-3 mb-4">
+    <div class="col-sm-4">
+        <div class="card border-danger text-center">
+            <div class="card-body py-3">
+                <div class="fs-2 fw-bold text-danger">{{ $stats['alert_count'] }}</div>
+                <div class="text-muted small">アラート商品数</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-4">
+        <div class="card border-warning text-center">
+            <div class="card-body py-3">
+                <div class="fs-2 fw-bold text-warning">{{ number_format($stats['total_deficit']) }}</div>
+                <div class="text-muted small">総不足数（発注点との差）</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-4">
+        <div class="card border-secondary text-center">
+            <div class="card-body py-3">
+                @if($stats['most_critical'])
+                <div class="fs-6 fw-bold">{{ $stats['most_critical']->name }}</div>
+                <div class="text-danger small">在庫: {{ $stats['most_critical']->stock_quantity }} / 発注点: {{ $stats['most_critical']->reorder_point }}</div>
+                @else
+                <div class="text-muted">—</div>
+                @endif
+                <div class="text-muted small mt-1">最も深刻な商品</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@if($alertProducts->isEmpty())
+<div class="alert alert-success">
+    <i class="bi bi-check-circle me-1"></i>現在アラート中の商品はありません。
+</div>
+@else
+<div class="card">
+    <div class="card-body p-0">
+        <table class="table table-hover mb-0">
+            <thead class="table-danger">
+                <tr>
+                    <th>SKU</th>
+                    <th>商品名</th>
+                    <th class="text-end">現在庫</th>
+                    <th class="text-end">発注点</th>
+                    <th class="text-end">不足数</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach($alertProducts as $product)
+                <tr>
+                    <td><code>{{ $product->sku }}</code></td>
+                    <td>{{ $product->name }}</td>
+                    <td class="text-end fw-bold text-danger">{{ number_format($product->stock_quantity) }}</td>
+                    <td class="text-end text-muted">{{ number_format($product->reorder_point) }}</td>
+                    <td class="text-end fw-bold">{{ number_format($product->deficit) }}</td>
+                    <td>
+                        <a href="{{ route('products.show', $product) }}" class="btn btn-sm btn-outline-primary">入庫</a>
+                    </td>
+                </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+</div>
+@endif
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Http\Controllers\ProductController;
+use App\Http\Controllers\StockTransactionController;
+use Illuminate\Support\Facades\Route;
+
+// Public JSON APIs (no auth required)
+Route::get('/api/v1/products', [ProductController::class, 'apiSearch'])->name('api.products.search');
+Route::get('/api/v1/products/low-stock', [ProductController::class, 'apiLowStock'])->name('api.products.low-stock');
+
+Route::middleware('auth')->group(function () {
+    Route::get('/', fn() => redirect()->route('products.index'));
+
+    // Static product routes BEFORE resource to avoid wildcard conflicts
+    Route::get('/products/reorder-list', [ProductController::class, 'reorderList'])->name('products.reorder-list');
+    Route::get('/products/qr-all', [ProductController::class, 'qrAll'])->name('products.qr-all');
+    Route::get('/products/suggest', [ProductController::class, 'suggest'])->name('products.suggest');
+    Route::get('/products/alerts', [ProductController::class, 'alertDashboard'])->name('products.alerts');
+
+    Route::resource('products', ProductController::class);
+
+    Route::get('/products/{product}/qrcode', [ProductController::class, 'qrcode'])->name('products.qrcode');
+    Route::get('/products/{product}/qrcode/download', [ProductController::class, 'qrcodeDownload'])->name('products.qrcode.download');
+    Route::get('/products/{product}/qrcode/download/svg', [ProductController::class, 'qrcodeSvgDownload'])->name('products.qrcode.download.svg');
+    Route::get('/products/{product}/label', [ProductController::class, 'label'])->name('products.label');
+    Route::post('/products/{product}/duplicate', [ProductController::class, 'duplicate'])->name('products.duplicate');
+
+    // Stock transaction routes — static before resource
+    Route::get('/stock-transactions/export', [StockTransactionController::class, 'export'])->name('stock-transactions.export');
+    Route::get('/stock-transactions/bulk', [StockTransactionController::class, 'bulk'])->name('stock-transactions.bulk');
+    Route::post('/stock-transactions/bulk', [StockTransactionController::class, 'bulkStore'])->name('stock-transactions.bulk.store');
+    Route::get('/stock-transactions', [StockTransactionController::class, 'index'])->name('stock-transactions.index');
+    Route::post('/products/{product}/stock', [StockTransactionController::class, 'store'])->name('stock-transactions.store');
+    Route::post('/products/{product}/quick-adjust', [StockTransactionController::class, 'quickAdjust'])->name('stock-transactions.quick-adjust');
+});


### PR DESCRIPTION
## Summary

- `ProductController::alertDashboard()` — queries `belowReorderPoint()`, computes `deficit = reorder_point - stock_quantity` per product, passes `alertProducts` + summary `$stats` to view
- `routes/web.php` — adds `GET /products/alerts` before `Route::resource`
- `products/alert-dashboard.blade.php` — 3 stat tiles (alert count / total deficit / most critical product), full table of alert products with deficit column and direct "入庫" link

## Test plan

- [ ] Navigate to `/products/alerts` — all below-reorder-point products appear
- [ ] Verify deficit column = reorder_point − stock_quantity for each row
- [ ] When no products are in alert state, a green success message is shown instead of the table


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjEM2ZSQARW5aVzEA72VJN)_