### PR TITLE
fix: add auth to event favorites routes and cap reviews pagination

### DIFF
--- a/laravel_project/app/Http/Controllers/TravelController.php
+++ b/laravel_project/app/Http/Controllers/TravelController.php
@@ -369,7 +369,12 @@ class TravelController extends Controller
      */
     public function reviews(Request $request, int $accommodationId): JsonResponse
     {
-        $perPage = $request->input('per_page', 10);
+        $request->validate([
+            'per_page' => 'nullable|integer|min:1|max:50',
+            'sort'     => 'nullable|in:newest,rating_high,rating_low,helpful',
+        ]);
+
+        $perPage = $request->integer('per_page', 10);
         $sort = $request->input('sort', 'newest');
 
         $query = Review::with('customer:id,name')

--- a/laravel_project/routes/web.php
+++ b/laravel_project/routes/web.php
@@ -103,10 +103,12 @@ Route::get('/events/calendar', [EventController::class, 'calendar'])->name('even
 // イベント詳細
 Route::get('/events/{id}', [EventController::class, 'show'])->name('events.show');
 
-// お気に入り
-Route::get('/events/my/favorites', [EventController::class, 'favorites'])->name('events.favorites');
-Route::post('/events/favorites', [EventController::class, 'addFavorite'])->name('events.favorites.add');
-Route::delete('/events/favorites/{eventId}', [EventController::class, 'removeFavorite'])->name('events.favorites.remove');
+// お気に入り (認証必須)
+Route::middleware('auth')->group(function () {
+    Route::get('/events/my/favorites', [EventController::class, 'favorites'])->name('events.favorites');
+    Route::post('/events/favorites', [EventController::class, 'addFavorite'])->name('events.favorites.add');
+    Route::delete('/events/favorites/{eventId}', [EventController::class, 'removeFavorite'])->name('events.favorites.remove');
+});
 
 // API
 Route::get('/api/events/search', [EventController::class, 'apiSearch'])->name('events.api.search');


### PR DESCRIPTION
## Summary

- **Event favorites auth** — `GET /events/my/favorites`, `POST /events/favorites`, and `DELETE /events/favorites/{eventId}` were accessible without authentication; wrapped in `Route::middleware('auth')->group()` to require login
- **Reviews pagination cap** — `TravelController::reviews()` accepted an unbounded `per_page` integer; now validated to `min:1|max:50` to prevent arbitrarily large DB queries; `sort` validated as an enum whitelist

## Security Impact

Without these fixes:
- Unauthenticated requests to `POST /events/favorites` would write arbitrary event data into server-side cache under the session ID, polluting the cache store
- `GET /events/favorites?per_page=1000000` on the reviews endpoint would execute a single query returning millions of rows, providing a DoS vector against the DB

## Test plan

- [ ] Unauthenticated POST to `/events/favorites` → expect redirect to login
- [ ] Unauthenticated DELETE to `/events/favorites/{id}` → expect redirect to login
- [ ] Authenticated user can add/remove/list favorites normally
- [ ] `GET /travel/accommodations/1/reviews?per_page=1000000` → expect 422
- [ ] `GET /travel/accommodations/1/reviews?sort=invalid` → expect 422
- [ ] `GET /travel/accommodations/1/reviews?per_page=20&sort=helpful` → expect 200


---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_