### PR TITLE
fix: prevent DOM-based XSS in elections and travel suggest views

### DIFF
--- a/laravel_project/resources/views/elections/show.blade.php
+++ b/laravel_project/resources/views/elections/show.blade.php
@@ -316,22 +316,36 @@ document.getElementById('validateAccuracy')?.addEventListener('click', function(
     .then(response => response.json())
     .then(data => {
         if (data.status === 'success') {
-            let html = '<table class="table table-sm"><thead><tr>';
-            html += '<th>政党</th><th>予測</th><th>実績</th><th>誤差</th><th>範囲内</th></tr></thead><tbody>';
+            const container = document.getElementById('accuracyResults');
+            container.textContent = '';
+
+            const table = document.createElement('table');
+            table.className = 'table table-sm';
+            table.innerHTML = '<thead><tr><th>政党</th><th>予測</th><th>実績</th><th>誤差</th><th>範囲内</th></tr></thead>';
+            const tbody = document.createElement('tbody');
 
             for (const [party, result] of Object.entries(data.data.validation)) {
-                html += `<tr>
-                    <td>${party}</td>
-                    <td>${result.predicted}</td>
-                    <td>${result.actual}</td>
-                    <td>${result.error}</td>
-                    <td>${result.within_range ? '<span class="badge bg-success">Yes</span>' : '<span class="badge bg-danger">No</span>'}</td>
-                </tr>`;
+                const tr = document.createElement('tr');
+                [party, result.predicted, result.actual, result.error].forEach(val => {
+                    const td = document.createElement('td');
+                    td.textContent = val;
+                    tr.appendChild(td);
+                });
+                const tdRange = document.createElement('td');
+                const badge = document.createElement('span');
+                badge.className = result.within_range ? 'badge bg-success' : 'badge bg-danger';
+                badge.textContent = result.within_range ? 'Yes' : 'No';
+                tdRange.appendChild(badge);
+                tr.appendChild(tdRange);
+                tbody.appendChild(tr);
             }
-            html += '</tbody></table>';
-            html += `<p class="text-muted">平均誤差: ${data.data.average_error}議席</p>`;
+            table.appendChild(tbody);
+            container.appendChild(table);
 
-            document.getElementById('accuracyResults').innerHTML = html;
+            const p = document.createElement('p');
+            p.className = 'text-muted';
+            p.textContent = `平均誤差: ${Number(data.data.average_error)}議席`;
+            container.appendChild(p);
         }
         this.disabled = false;
     });
@@ -344,9 +358,10 @@ document.getElementById('addResultModal')?.addEventListener('show.bs.modal', fun
     .then(response => response.json())
     .then(data => {
         const select = this.querySelector('select[name="district_id"]');
-        select.innerHTML = '<option value="">選択してください</option>';
+        select.textContent = '';
+        select.appendChild(new Option('選択してください', ''));
         data.data.forEach(district => {
-            select.innerHTML += `<option value="${district.id}">${district.name}</option>`;
+            select.appendChild(new Option(district.name, district.id));
         });
     });
 
@@ -355,9 +370,10 @@ document.getElementById('addResultModal')?.addEventListener('show.bs.modal', fun
     .then(response => response.json())
     .then(data => {
         const select = this.querySelector('select[name="party_id"]');
-        select.innerHTML = '<option value="">選択してください</option>';
+        select.textContent = '';
+        select.appendChild(new Option('選択してください', ''));
         data.data.forEach(party => {
-            select.innerHTML += `<option value="${party.id}">${party.name}</option>`;
+            select.appendChild(new Option(party.name, party.id));
         });
     });
 });

--- a/laravel_project/resources/views/travel/index.blade.php
+++ b/laravel_project/resources/views/travel/index.blade.php
@@ -267,12 +267,21 @@ keywordInput?.addEventListener('input', function() {
                     return;
                 }
 
-                suggestDropdown.innerHTML = data.data.map(item => `
-                    <a class="dropdown-item" href="#" data-type="${item.type}" data-id="${item.id}" data-name="${item.name}">
-                        <small class="text-muted">${item.type === 'area' ? 'エリア' : '施設'}</small>
-                        ${item.label}
-                    </a>
-                `).join('');
+                suggestDropdown.textContent = '';
+                data.data.forEach(item => {
+                    const a = document.createElement('a');
+                    a.className = 'dropdown-item';
+                    a.href = '#';
+                    a.dataset.type = item.type;
+                    a.dataset.id = item.id;
+                    a.dataset.name = item.name;
+                    const small = document.createElement('small');
+                    small.className = 'text-muted';
+                    small.textContent = item.type === 'area' ? 'エリア' : '施設';
+                    a.appendChild(small);
+                    a.appendChild(document.createTextNode(' ' + item.label));
+                    suggestDropdown.appendChild(a);
+                });
                 suggestDropdown.style.display = 'block';
             });
     }, 300);


### PR DESCRIPTION
## Summary

Replace all `innerHTML` template-literal injections with safe DOM API calls in two views.

**`elections/show.blade.php`**
- Accuracy validation table: replaced `html += \`<td>${party}</td>...\`` + `innerHTML = html` with `createElement`/`textContent`/`appendChild` so party names from the API cannot inject HTML
- District and party `<select>` population: replaced `select.innerHTML += \`<option value="${id}">${name}</option>\`` with `new Option(text, value)` which escapes both the display text and value attribute

**`travel/index.blade.php`**
- Suggest dropdown: replaced `innerHTML = items.map(item => \`...\`).join('')` with `createElement` + `textContent` + `dataset` assignments so `item.label` and `item.name` from the suggest API cannot inject HTML or break out of attribute boundaries

## Security Impact

An attacker with write access to party/district names (or a compromised admin account) could store an XSS payload such as ```'&lt;img src=x onerror=alert(1)&gt;'``` in a party name. When the elections modal loaded districts or parties, that payload would execute in any visitor's browser (stored XSS). The suggest dropdown similarly reflected whatever `label`/`name` values came from the server API without escaping.

## Test plan

- [ ] Create a party or district with name `<script>alert(1)</script>` → confirm no script executes when loading the elections result modal
- [ ] Confirm district and party `<select>` dropdowns still populate correctly with safe names
- [ ] Search with keyword in travel search → confirm autocomplete suggestions render correctly
- [ ] Confirm suggestion with name containing `"` or `<` renders as text, not HTML


---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_