### PR TITLE
feat: allow user to choose per-page size on transaction history

### DIFF
--- a/app/Http/Controllers/StockTransactionController.php
+++ b/app/Http/Controllers/StockTransactionController.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\StockTransactionType;
+use App\Http\Requests\StockOperationRequest;
+use App\Models\Product;
+use App\Services\StockService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+
+class StockTransactionController extends Controller
+{
+    public function __construct(
+        private StockService $stockService
+    ) {}
+
+    public function store(StockOperationRequest $request, Product $product)
+    {
+        try {
+            $type = StockTransactionType::from($request->input('type'));
+            $quantity = $request->integer('quantity');
+            $reason = $request->input('reason');
+
+            $transaction = match ($type) {
+                StockTransactionType::IN => $this->stockService->stockIn($product, $quantity, $reason),
+                StockTransactionType::OUT => $this->stockService->stockOut($product, $quantity, $reason),
+                StockTransactionType::ADJUST => $this->stockService->adjust($product, $quantity, $reason),
+            };
+
+            return redirect()->route('products.show', $product)
+                ->with('success', "{$type->label()}処理が完了しました");
+
+        } catch (\InvalidArgumentException $e) {
+            return back()->withErrors(['quantity' => $e->getMessage()])->withInput();
+        } catch (\Exception $e) {
+            Log::error('Stock operation failed', [
+                'product_id' => $product->id,
+                'type' => $request->input('type'),
+                'error' => $e->getMessage(),
+            ]);
+            return back()->withErrors(['error' => '在庫操作に失敗しました'])->withInput();
+        }
+    }
+
+    public function index(Request $request)
+    {
+        $query = \App\Models\StockTransaction::query()->with('product');
+
+        if ($request->filled('type')) {
+            $query->where('type', $request->input('type'));
+        }
+        if ($request->filled('product_id')) {
+            $query->where('product_id', $request->integer('product_id'));
+        }
+        if ($request->filled('date_from')) {
+            $query->whereDate('created_at', '>=', $request->input('date_from'));
+        }
+        if ($request->filled('date_to')) {
+            $query->whereDate('created_at', '<=', $request->input('date_to'));
+        }
+
+        $perPage = in_array((int) $request->input('per_page'), [25, 50, 100]) ? (int) $request->input('per_page') : 50;
+
+        $transactions = $query->latest()->paginate($perPage);
+
+        return view('stock-transactions.index', compact('transactions', 'perPage'));
+    }
+
+    public function export(Request $request)
+    {
+        $query = \App\Models\StockTransaction::query()->with('product');
+
+        if ($request->filled('type')) $query->where('type', $request->input('type'));
+        if ($request->filled('product_id')) $query->where('product_id', $request->integer('product_id'));
+        if ($request->filled('date_from')) $query->whereDate('created_at', '>=', $request->input('date_from'));
+        if ($request->filled('date_to')) $query->whereDate('created_at', '<=', $request->input('date_to'));
+
+        $transactions = $query->latest()->get();
+
+        $headers = [
+            'Content-Type'        => 'text/csv; charset=UTF-8',
+            'Content-Disposition' => 'attachment; filename="stock_transactions_' . now()->format('Ymd_His') . '.csv"',
+        ];
+
+        $callback = function () use ($transactions) {
+            $out = fopen('php://output', 'w');
+            fprintf($out, chr(0xEF) . chr(0xBB) . chr(0xBF));
+            fputcsv($out, ['日時', '商品SKU', '商品名', '操作種別', '数量', '理由']);
+            foreach ($transactions as $tx) {
+                fputcsv($out, [
+                    $tx->created_at->format('Y-m-d H:i:s'),
+                    $tx->product->sku ?? '',
+                    $tx->product->name ?? '',
+                    $tx->type->label(),
+                    $tx->quantity,
+                    $tx->reason ?? '',
+                ]);
+            }
+            fclose($out);
+        };
+
+        return response()->stream($callback, 200, $headers);
+    }
+
+    public function bulk()
+    {
+        $products = Product::orderBy('name')->get();
+        return view('stock-transactions.bulk', compact('products'));
+    }
+
+    public function bulkStore(Request $request)
+    {
+        $entries = $request->input('entries', []);
+        $count = 0;
+        foreach ($entries as $entry) {
+            if (empty($entry['product_id']) || empty($entry['quantity']) || (int)$entry['quantity'] <= 0) continue;
+            $product = Product::find((int)$entry['product_id']);
+            if (!$product) continue;
+            $this->stockService->stockIn($product, (int)$entry['quantity'], $entry['reason'] ?? '一括入庫');
+            $count++;
+        }
+        return redirect()->route('stock-transactions.index')->with('success', "{$count}件の商品を入庫しました");
+    }
+
+    public function quickAdjust(Request $request, Product $product)
+    {
+        $request->validate(['delta' => ['required', 'integer', 'in:-1,1']]);
+        $delta = $request->integer('delta');
+        if ($delta > 0) {
+            $this->stockService->stockIn($product, 1, 'クイック入庫');
+        } else {
+            $this->stockService->stockOut($product, 1, 'クイック出庫');
+        }
+        return response()->json(['stock' => $product->fresh()->stock_quantity]);
+    }
+}

--- a/resources/views/stock-transactions/index.blade.php
+++ b/resources/views/stock-transactions/index.blade.php
@@ -1,0 +1,89 @@
+@extends('layouts.app')
+
+@section('title', '在庫履歴')
+
+@section('content')
+<div class="d-flex justify-content-between align-items-center mt-4 mb-3">
+    <h2><i class="bi bi-clock-history me-2"></i>在庫履歴</h2>
+    <div class="d-flex gap-2">
+        <a href="{{ route('stock-transactions.export', request()->query()) }}" class="btn btn-outline-success">
+            <i class="bi bi-file-earmark-spreadsheet me-1"></i>CSVエクスポート
+        </a>
+        <a href="{{ route('products.index') }}" class="btn btn-outline-secondary">
+            <i class="bi bi-box-seam me-1"></i>商品一覧
+        </a>
+    </div>
+</div>
+
+<div class="card mb-4">
+    <div class="card-body">
+        <form method="GET" action="{{ route('stock-transactions.index') }}" class="row g-2 align-items-end">
+            <div class="col-md-2">
+                <label class="form-label fw-semibold">種別</label>
+                <select name="type" class="form-select">
+                    <option value="">すべて</option>
+                    <option value="IN" @selected(request('type')==='IN')>入庫</option>
+                    <option value="OUT" @selected(request('type')==='OUT')>出庫</option>
+                    <option value="ADJUST" @selected(request('type')==='ADJUST')>調整</option>
+                </select>
+            </div>
+            <div class="col-md-2">
+                <label class="form-label fw-semibold">開始日</label>
+                <input type="date" name="date_from" class="form-control" value="{{ request('date_from') }}">
+            </div>
+            <div class="col-md-2">
+                <label class="form-label fw-semibold">終了日</label>
+                <input type="date" name="date_to" class="form-control" value="{{ request('date_to') }}">
+            </div>
+            <div class="col-md-2">
+                <label class="form-label fw-semibold">表示件数</label>
+                <select name="per_page" class="form-select">
+                    @foreach([25, 50, 100] as $n)
+                    <option value="{{ $n }}" @selected($perPage === $n)>{{ $n }}件</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="col-md-2">
+                <button type="submit" class="btn btn-primary w-100">絞り込み</button>
+            </div>
+            <div class="col-md-2">
+                <a href="{{ route('stock-transactions.index') }}" class="btn btn-secondary w-100">クリア</a>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-body p-0">
+        <table class="table table-hover mb-0">
+            <thead>
+                <tr>
+                    <th>日時</th><th>商品</th><th>SKU</th>
+                    <th class="text-center">種別</th>
+                    <th class="text-end">数量</th>
+                    <th>理由</th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse($transactions as $tx)
+                <tr>
+                    <td class="text-muted small">{{ $tx->created_at->format('Y/m/d H:i') }}</td>
+                    <td><a href="{{ route('products.show', $tx->product) }}" class="text-decoration-none">{{ $tx->product->name }}</a></td>
+                    <td><code>{{ $tx->product->sku }}</code></td>
+                    <td class="text-center">
+                        @if($tx->type->value === 'IN')<span class="badge bg-success">入庫</span>
+                        @elseif($tx->type->value === 'OUT')<span class="badge bg-danger">出庫</span>
+                        @else<span class="badge bg-secondary">調整</span>@endif
+                    </td>
+                    <td class="text-end fw-semibold">{{ number_format($tx->quantity) }}</td>
+                    <td class="text-muted small">{{ $tx->reason ?? '-' }}</td>
+                </tr>
+                @empty
+                <tr><td colspan="6" class="text-center text-muted py-4">履歴がありません</td></tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+</div>
+<div class="mt-3">{{ $transactions->withQueryString()->links() }}</div>
+@endsection


### PR DESCRIPTION
## Summary

- `StockTransactionController::index()` — reads `per_page` query param, whitelists `[25, 50, 100]`, defaults to 50
- `stock-transactions/index.blade.php` — adds a "表示件数" `<select>` (25件 / 50件 / 100件) inside the filter form

## Test plan

- [ ] Select "100件" and submit — up to 100 rows appear per page
- [ ] Pagination links carry the `per_page` parameter via `withQueryString()`
- [ ] Invalid or missing `per_page` values default to 50


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjEM2ZSQARW5aVzEA72VJN)_