### PR TITLE
feat: add per-product IN/OUT/ADJUST transaction summary page

### DIFF
--- a/app/Http/Controllers/StockTransactionController.php
+++ b/app/Http/Controllers/StockTransactionController.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Enums\StockTransactionType;
+use App\Http\Requests\StockOperationRequest;
+use App\Models\Product;
+use App\Models\StockTransaction;
+use App\Services\StockService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class StockTransactionController extends Controller
+{
+    public function __construct(
+        private StockService $stockService
+    ) {}
+
+    public function store(StockOperationRequest $request, Product $product)
+    {
+        try {
+            $type = StockTransactionType::from($request->input('type'));
+            $transaction = match ($type) {
+                StockTransactionType::IN => $this->stockService->stockIn($product, $request->integer('quantity'), $request->input('reason')),
+                StockTransactionType::OUT => $this->stockService->stockOut($product, $request->integer('quantity'), $request->input('reason')),
+                StockTransactionType::ADJUST => $this->stockService->adjust($product, $request->integer('quantity'), $request->input('reason')),
+            };
+            return redirect()->route('products.show', $product)->with('success', "{$type->label()}処理が完了しました");
+        } catch (\InvalidArgumentException $e) {
+            return back()->withErrors(['quantity' => $e->getMessage()])->withInput();
+        } catch (\Exception $e) {
+            Log::error('Stock operation failed', ['product_id' => $product->id, 'error' => $e->getMessage()]);
+            return back()->withErrors(['error' => '在庫操作に失敗しました'])->withInput();
+        }
+    }
+
+    public function index(Request $request)
+    {
+        $query = StockTransaction::query()->with('product');
+        if ($request->filled('type')) $query->where('type', $request->input('type'));
+        if ($request->filled('product_id')) $query->where('product_id', $request->integer('product_id'));
+        if ($request->filled('date_from')) $query->whereDate('created_at', '>=', $request->input('date_from'));
+        if ($request->filled('date_to')) $query->whereDate('created_at', '<=', $request->input('date_to'));
+        $transactions = $query->latest()->paginate(50);
+        return view('stock-transactions.index', compact('transactions'));
+    }
+
+    public function export(Request $request)
+    {
+        $query = StockTransaction::query()->with('product');
+        if ($request->filled('type')) $query->where('type', $request->input('type'));
+        if ($request->filled('product_id')) $query->where('product_id', $request->integer('product_id'));
+        $transactions = $query->latest()->get();
+        $headers = [
+            'Content-Type'        => 'text/csv; charset=UTF-8',
+            'Content-Disposition' => 'attachment; filename="stock_transactions_' . now()->format('Ymd_His') . '.csv"',
+        ];
+        $callback = function () use ($transactions) {
+            $out = fopen('php://output', 'w');
+            fprintf($out, chr(0xEF) . chr(0xBB) . chr(0xBF));
+            fputcsv($out, ['日時', '商品SKU', '商品名', '操作種別', '数量', '理由']);
+            foreach ($transactions as $tx) {
+                fputcsv($out, [$tx->created_at->format('Y-m-d H:i:s'), $tx->product->sku ?? '', $tx->product->name ?? '', $tx->type->label(), $tx->quantity, $tx->reason ?? '']);
+            }
+            fclose($out);
+        };
+        return response()->stream($callback, 200, $headers);
+    }
+
+    public function bulk()
+    {
+        $products = Product::orderBy('name')->get();
+        return view('stock-transactions.bulk', compact('products'));
+    }
+
+    public function bulkStore(Request $request)
+    {
+        $count = 0;
+        foreach ($request->input('entries', []) as $entry) {
+            if (empty($entry['product_id']) || empty($entry['quantity']) || (int)$entry['quantity'] <= 0) continue;
+            $product = Product::find((int)$entry['product_id']);
+            if (!$product) continue;
+            $this->stockService->stockIn($product, (int)$entry['quantity'], $entry['reason'] ?? '一括入庫');
+            $count++;
+        }
+        return redirect()->route('stock-transactions.index')->with('success', "{$count}件の商品を入庫しました");
+    }
+
+    public function quickAdjust(Request $request, Product $product)
+    {
+        $request->validate(['delta' => ['required', 'integer', 'in:-1,1']]);
+        $delta = $request->integer('delta');
+        $delta > 0
+            ? $this->stockService->stockIn($product, 1, 'クイック入庫')
+            : $this->stockService->stockOut($product, 1, 'クイック出庫');
+        return response()->json(['stock' => $product->fresh()->stock_quantity]);
+    }
+
+    public function summary()
+    {
+        $rows = StockTransaction::query()
+            ->select('product_id', 'type', DB::raw('SUM(quantity) as total_qty'), DB::raw('COUNT(*) as tx_count'))
+            ->with('product:id,sku,name,stock_quantity')
+            ->groupBy('product_id', 'type')
+            ->get();
+
+        $summary = [];
+        foreach ($rows as $row) {
+            $pid = $row->product_id;
+            if (!isset($summary[$pid])) {
+                $summary[$pid] = [
+                    'product' => $row->product,
+                    'IN' => 0, 'OUT' => 0, 'ADJUST' => 0,
+                ];
+            }
+            $summary[$pid][$row->type->value] = (int) $row->total_qty;
+        }
+
+        $summary = collect(array_values($summary))->sortBy(fn($r) => $r['product']?->name ?? '');
+
+        return view('stock-transactions.summary', compact('summary'));
+    }
+}

--- a/resources/views/stock-transactions/summary.blade.php
+++ b/resources/views/stock-transactions/summary.blade.php
@@ -1,0 +1,47 @@
+@extends('layouts.app')
+
+@section('title', '商品別入出庫サマリー')
+
+@section('content')
+<div class="d-flex justify-content-between align-items-center mt-4 mb-3">
+    <h2><i class="bi bi-bar-chart me-2"></i>商品別入出庫サマリー</h2>
+    <a href="{{ route('stock-transactions.index') }}" class="btn btn-outline-secondary">
+        <i class="bi bi-clock-history me-1"></i>履歴一覧
+    </a>
+</div>
+
+<div class="card">
+    <div class="card-body p-0">
+        <table class="table table-hover mb-0">
+            <thead>
+                <tr>
+                    <th>SKU</th>
+                    <th>商品名</th>
+                    <th class="text-end text-success">入庫計</th>
+                    <th class="text-end text-danger">出庫計</th>
+                    <th class="text-end text-secondary">調整計</th>
+                    <th class="text-end">現在庫</th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse($summary as $row)
+                <tr>
+                    <td><code>{{ $row['product']?->sku }}</code></td>
+                    <td>
+                        <a href="{{ route('products.show', $row['product']) }}" class="text-decoration-none">
+                            {{ $row['product']?->name }}
+                        </a>
+                    </td>
+                    <td class="text-end text-success fw-semibold">+{{ number_format($row['IN']) }}</td>
+                    <td class="text-end text-danger fw-semibold">-{{ number_format($row['OUT']) }}</td>
+                    <td class="text-end text-secondary">{{ number_format($row['ADJUST']) }}</td>
+                    <td class="text-end fw-bold">{{ number_format($row['product']?->stock_quantity ?? 0) }}</td>
+                </tr>
+                @empty
+                <tr><td colspan="6" class="text-center text-muted py-4">データがありません</td></tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Http\Controllers\ProductController;
+use App\Http\Controllers\StockTransactionController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/api/v1/products', [ProductController::class, 'apiSearch'])->name('api.products.search');
+Route::get('/api/v1/products/low-stock', [ProductController::class, 'apiLowStock'])->name('api.products.low-stock');
+
+Route::middleware('auth')->group(function () {
+    Route::get('/', fn() => redirect()->route('products.index'));
+
+    Route::get('/products/reorder-list', [ProductController::class, 'reorderList'])->name('products.reorder-list');
+    Route::get('/products/suggest', [ProductController::class, 'suggest'])->name('products.suggest');
+
+    Route::resource('products', ProductController::class);
+
+    Route::get('/products/{product}/qrcode', [ProductController::class, 'qrcode'])->name('products.qrcode');
+    Route::get('/products/{product}/qrcode/download', [ProductController::class, 'qrcodeDownload'])->name('products.qrcode.download');
+    Route::get('/products/{product}/qrcode/download/svg', [ProductController::class, 'qrcodeSvgDownload'])->name('products.qrcode.download.svg');
+    Route::get('/products/{product}/label', [ProductController::class, 'label'])->name('products.label');
+    Route::post('/products/{product}/duplicate', [ProductController::class, 'duplicate'])->name('products.duplicate');
+
+    Route::get('/stock-transactions/export', [StockTransactionController::class, 'export'])->name('stock-transactions.export');
+    Route::get('/stock-transactions/bulk', [StockTransactionController::class, 'bulk'])->name('stock-transactions.bulk');
+    Route::post('/stock-transactions/bulk', [StockTransactionController::class, 'bulkStore'])->name('stock-transactions.bulk.store');
+    Route::get('/stock-transactions/summary', [StockTransactionController::class, 'summary'])->name('stock-transactions.summary');
+    Route::get('/stock-transactions', [StockTransactionController::class, 'index'])->name('stock-transactions.index');
+    Route::post('/products/{product}/stock', [StockTransactionController::class, 'store'])->name('stock-transactions.store');
+    Route::post('/products/{product}/quick-adjust', [StockTransactionController::class, 'quickAdjust'])->name('stock-transactions.quick-adjust');
+});


### PR DESCRIPTION
## Summary

- `StockTransactionController::summary()` — aggregates total IN / OUT / ADJUST quantities per product via `GROUP BY product_id, type`; sorts by product name
- `routes/web.php` — adds `GET /stock-transactions/summary` before `stock-transactions.index`
- `stock-transactions/summary.blade.php` — table with color-coded columns: +入庫計 / -出庫計 / 調整計 / 現在庫

## Test plan

- [ ] Navigate to `/stock-transactions/summary` — every product with at least one transaction appears
- [ ] IN column is green / OUT is red / ADJUST is grey
- [ ] Clicking a product name links to its detail page


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjEM2ZSQARW5aVzEA72VJN)_