### PR TITLE
fix: prevent CSV formula injection and cap event_data cache payload

### DIFF
--- a/laravel_project/app/Http/Controllers/ElectionController.php
+++ b/laravel_project/app/Http/Controllers/ElectionController.php
@@ -478,7 +478,7 @@ class ElectionController extends Controller
             // データ行
             foreach ($data['results'] as $partyName => $result) {
                 fputcsv($file, [
-                    $partyName,
+                    $this->sanitizeCsvCell((string) $partyName),
                     $result['total_seats'],
                     $result['total_votes'],
                     '-',
@@ -490,5 +490,14 @@ class ElectionController extends Controller
         };
 
         return response()->stream($callback, 200, $headers);
+    }
+
+    private function sanitizeCsvCell(string $value): string
+    {
+        if ($value !== '' && in_array($value[0], ['=', '+', '-', '@', "\t", "\r"], true)) {
+            return "\t" . $value;
+        }
+
+        return $value;
     }
 }

--- a/laravel_project/app/Http/Controllers/EventController.php
+++ b/laravel_project/app/Http/Controllers/EventController.php
@@ -133,8 +133,9 @@ class EventController extends Controller
     public function addFavorite(Request $request)
     {
         $request->validate([
-            'event_id' => 'required|string',
-            'event_data' => 'required|array',
+            'event_id'   => 'required|string|max:100',
+            'event_data' => 'required|array|max:20',
+            'event_data.*' => 'nullable|scalar|max:500',
         ]);
 
         $userId = auth()->id() ?? session()->getId();


### PR DESCRIPTION
## Summary

Two unrelated but similar-severity fixes bundled together:

**CSV formula injection — `ElectionController::generateCsvReport()`**
- Added a private `sanitizeCsvCell()` helper that prefixes any cell value starting with `=`, `+`, `-`, `@`, tab, or carriage-return with a tab character before passing it to `fputcsv()`
- Applied to the `$partyName` column (the only user-controlled string in the CSV output)
- Numeric columns (`total_seats`, `total_votes`) are already safe integers

**Cache store flooding — `EventController::addFavorite()`**
- `event_id` capped at `max:100` characters
- `event_data` array capped at `max:20` keys
- Each value in `event_data` validated as `scalar` with `max:500` characters
- Previously an attacker could submit an arbitrarily large payload that would be stored verbatim in the server-side cache under a session-keyed key, exhausting the cache store

## Security Impact

**CSV injection**: A party name stored in the database as `=cmd|'/C calc'!A0` would execute when a spreadsheet application opened the exported file. An attacker with admin access (or a compromised admin account) could plant this payload.

**Cache flooding**: `POST /events/favorites` with `event_data` containing thousands of keys or megabyte-sized string values would store an unbounded payload in the cache, potentially exhausting available cache memory and causing denial of service.

## Test plan

- [ ] Export a CSV for an election whose party name starts with `=` → confirm the CSV cell is prefixed with a tab
- [ ] Normal party names export unchanged
- [ ] POST to `/events/favorites` with `event_data` containing 21 keys → expect 422
- [ ] POST to `/events/favorites` with `event_data.field` value over 500 chars → expect 422
- [ ] Valid favorites still save correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_