### PR TITLE
feat: show recently updated products panel on products index

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Product;
+use Illuminate\Http\Request;
+use SimpleSoftwareIO\QrCode\Facades\QrCode;
+
+class ProductController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = Product::query();
+        if ($request->filled('search')) {
+            $search = $request->input('search');
+            $query->where(fn($q) => $q->where('sku', 'like', "%{$search}%")->orWhere('name', 'like', "%{$search}%"));
+        }
+        if ($request->boolean('alert_only')) $query->belowReorderPoint();
+        match ($request->input('sort', 'stock_asc')) {
+            'stock_desc' => $query->orderBy('stock_quantity', 'desc'),
+            'name'       => $query->orderBy('name', 'asc'),
+            default      => $query->orderBy('stock_quantity', 'asc'),
+        };
+        $products = $query->paginate(20);
+
+        $recentlyUpdated = Product::orderBy('updated_at', 'desc')->limit(5)->get();
+
+        return view('products.index', compact('products', 'recentlyUpdated'));
+    }
+
+    public function create() { return view('products.create'); }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'sku'            => ['required', 'string', 'max:100', 'unique:products'],
+            'name'           => ['required', 'string', 'max:255'],
+            'description'    => ['nullable', 'string'],
+            'stock_quantity' => ['required', 'integer', 'min:0'],
+            'reorder_point'  => ['required', 'integer', 'min:0'],
+        ]);
+        Product::create($validated);
+        return redirect()->route('products.index')->with('success', '商品を登録しました');
+    }
+
+    public function show(Product $product)
+    {
+        $transactions = $product->stockTransactions()->latest()->paginate(50);
+        return view('products.show', compact('product', 'transactions'));
+    }
+
+    public function edit(Product $product) { return view('products.edit', compact('product')); }
+
+    public function update(Request $request, Product $product)
+    {
+        $validated = $request->validate([
+            'sku'           => ['required', 'string', 'max:100', 'unique:products,sku,' . $product->id],
+            'name'          => ['required', 'string', 'max:255'],
+            'description'   => ['nullable', 'string'],
+            'reorder_point' => ['required', 'integer', 'min:0'],
+        ]);
+        $product->update($validated);
+        return redirect()->route('products.index')->with('success', '商品情報を更新しました');
+    }
+
+    public function destroy(Product $product)
+    {
+        $product->delete();
+        return redirect()->route('products.index')->with('success', '商品を削除しました');
+    }
+
+    public function qrcode(Product $product)
+    {
+        $svg = QrCode::format('svg')->size(200)->errorCorrection('M')->generate(route('products.show', $product));
+        return response($svg, 200)->header('Content-Type', 'image/svg+xml');
+    }
+
+    public function qrcodeDownload(Product $product)
+    {
+        $png = QrCode::format('png')->size(300)->errorCorrection('M')->generate(route('products.show', $product));
+        return response($png, 200)->header('Content-Type', 'image/png')->header('Content-Disposition', 'attachment; filename="qrcode_' . $product->sku . '.png"');
+    }
+
+    public function qrcodeSvgDownload(Product $product)
+    {
+        $svg = QrCode::format('svg')->size(300)->errorCorrection('M')->generate(route('products.show', $product));
+        return response($svg, 200)->header('Content-Type', 'image/svg+xml')->header('Content-Disposition', 'attachment; filename="qrcode_' . $product->sku . '.svg"');
+    }
+
+    public function label(Product $product) { return view('products.qr-label', compact('product')); }
+
+    public function reorderList()
+    {
+        $products = Product::belowReorderPoint()->orderBy('stock_quantity', 'asc')->get()
+            ->map(fn($p) => tap($p, fn($p) => $p->order_quantity = max(0, $p->reorder_point * 2 - $p->stock_quantity)));
+        return view('products.reorder-list', compact('products'));
+    }
+
+    public function duplicate(Product $product)
+    {
+        $copy = $product->replicate();
+        $copy->sku = $product->sku . '-copy-' . substr(uniqid(), -4);
+        $copy->name = $product->name . '（コピー）';
+        $copy->stock_quantity = 0;
+        $copy->save();
+        return redirect()->route('products.edit', $copy)->with('success', '商品を複製しました。内容を確認して保存してください。');
+    }
+
+    public function suggest(Request $request)
+    {
+        $q = $request->input('q', '');
+        if (strlen($q) < 1) return response()->json([]);
+        return response()->json(Product::where('sku', 'like', "%{$q}%")->orWhere('name', 'like', "%{$q}%")->orderBy('name')->limit(10)->get(['id', 'sku', 'name']));
+    }
+
+    public function apiSearch(Request $request)
+    {
+        $query = Product::query();
+        if ($request->filled('q')) {
+            $q = $request->input('q');
+            $query->where(fn($sq) => $sq->where('sku', 'like', "%{$q}%")->orWhere('name', 'like', "%{$q}%"));
+        }
+        if ($request->boolean('alert_only')) $query->belowReorderPoint();
+        $products = $query->orderBy('name')->limit(100)->get(['id', 'sku', 'name', 'stock_quantity', 'reorder_point']);
+        return response()->json(['data' => $products, 'total' => $products->count()]);
+    }
+
+    public function apiLowStock()
+    {
+        $products = Product::belowReorderPoint()->orderBy('stock_quantity', 'asc')->get(['id', 'sku', 'name', 'stock_quantity', 'reorder_point']);
+        return response()->json(['data' => $products, 'total' => $products->count()]);
+    }
+}

--- a/resources/views/products/_recently-updated.blade.php
+++ b/resources/views/products/_recently-updated.blade.php
@@ -1,0 +1,23 @@
+@if($recentlyUpdated->isNotEmpty())
+<div class="card mb-3">
+    <div class="card-header d-flex justify-content-between align-items-center py-2">
+        <span class="fw-semibold small"><i class="bi bi-clock me-1"></i>最近更新された商品</span>
+    </div>
+    <div class="card-body p-0">
+        <ul class="list-group list-group-flush">
+            @foreach($recentlyUpdated as $p)
+            <li class="list-group-item d-flex justify-content-between align-items-center py-2">
+                <div>
+                    <a href="{{ route('products.show', $p) }}" class="text-decoration-none fw-semibold">{{ $p->name }}</a>
+                    <span class="text-muted small ms-2"><code>{{ $p->sku }}</code></span>
+                </div>
+                <div class="text-end">
+                    <span class="fw-bold {{ $p->isLowStock() ? 'text-danger' : 'text-success' }}">{{ number_format($p->stock_quantity) }}</span>
+                    <span class="text-muted small ms-2">{{ $p->updated_at->diffForHumans() }}</span>
+                </div>
+            </li>
+            @endforeach
+        </ul>
+    </div>
+</div>
+@endif


### PR DESCRIPTION
## Summary

- `ProductController::index()` — queries top 5 products by `updated_at DESC` and passes `$recentlyUpdated` to the view
- `products/_recently-updated.blade.php` — new partial: list-group showing product name, SKU, current stock (red if alert), and human-readable "N分前" timestamp

## Test plan

- [ ] Products list shows the "最近更新された商品" card above the table
- [ ] Performing a stock operation on a product moves it to the top of the recent list
- [ ] Stock in alert state shows red text in the panel


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjEM2ZSQARW5aVzEA72VJN)_