### PR TITLE
feat: import products from uploaded CSV file

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Product;
+use Illuminate\Http\Request;
+use SimpleSoftwareIO\QrCode\Facades\QrCode;
+
+class ProductController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = Product::query();
+        if ($request->filled('search')) {
+            $search = $request->input('search');
+            $query->where(fn($q) => $q->where('sku', 'like', "%{$search}%")->orWhere('name', 'like', "%{$search}%"));
+        }
+        if ($request->boolean('alert_only')) $query->belowReorderPoint();
+        match ($request->input('sort', 'stock_asc')) {
+            'stock_desc' => $query->orderBy('stock_quantity', 'desc'),
+            'name'       => $query->orderBy('name', 'asc'),
+            default      => $query->orderBy('stock_quantity', 'asc'),
+        };
+        $products = $query->paginate(20);
+        return view('products.index', compact('products'));
+    }
+
+    public function create() { return view('products.create'); }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'sku'            => ['required', 'string', 'max:100', 'unique:products'],
+            'name'           => ['required', 'string', 'max:255'],
+            'description'    => ['nullable', 'string'],
+            'stock_quantity' => ['required', 'integer', 'min:0'],
+            'reorder_point'  => ['required', 'integer', 'min:0'],
+        ]);
+        Product::create($validated);
+        return redirect()->route('products.index')->with('success', '商品を登録しました');
+    }
+
+    public function show(Product $product)
+    {
+        $transactions = $product->stockTransactions()->latest()->paginate(50);
+        return view('products.show', compact('product', 'transactions'));
+    }
+
+    public function edit(Product $product) { return view('products.edit', compact('product')); }
+
+    public function update(Request $request, Product $product)
+    {
+        $validated = $request->validate([
+            'sku'           => ['required', 'string', 'max:100', 'unique:products,sku,' . $product->id],
+            'name'          => ['required', 'string', 'max:255'],
+            'description'   => ['nullable', 'string'],
+            'reorder_point' => ['required', 'integer', 'min:0'],
+        ]);
+        $product->update($validated);
+        return redirect()->route('products.index')->with('success', '商品情報を更新しました');
+    }
+
+    public function destroy(Product $product)
+    {
+        $product->delete();
+        return redirect()->route('products.index')->with('success', '商品を削除しました');
+    }
+
+    public function qrcode(Product $product)
+    {
+        $svg = QrCode::format('svg')->size(200)->errorCorrection('M')->generate(route('products.show', $product));
+        return response($svg, 200)->header('Content-Type', 'image/svg+xml');
+    }
+
+    public function qrcodeDownload(Product $product)
+    {
+        $png = QrCode::format('png')->size(300)->errorCorrection('M')->generate(route('products.show', $product));
+        return response($png, 200)->header('Content-Type', 'image/png')->header('Content-Disposition', 'attachment; filename="qrcode_' . $product->sku . '.png"');
+    }
+
+    public function qrcodeSvgDownload(Product $product)
+    {
+        $svg = QrCode::format('svg')->size(300)->errorCorrection('M')->generate(route('products.show', $product));
+        return response($svg, 200)->header('Content-Type', 'image/svg+xml')->header('Content-Disposition', 'attachment; filename="qrcode_' . $product->sku . '.svg"');
+    }
+
+    public function label(Product $product) { return view('products.qr-label', compact('product')); }
+
+    public function importForm()
+    {
+        return view('products.import');
+    }
+
+    public function importCsv(Request $request)
+    {
+        $request->validate([
+            'csv_file' => ['required', 'file', 'mimes:csv,txt', 'max:2048'],
+        ]);
+
+        $path = $request->file('csv_file')->getRealPath();
+        $handle = fopen($path, 'r');
+
+        $imported = 0;
+        $skipped  = 0;
+        $firstRow = true;
+
+        while (($row = fgetcsv($handle)) !== false) {
+            if ($firstRow) { $firstRow = false; continue; } // skip header
+
+            [$sku, $name, $description, $stock, $reorder] = array_pad($row, 5, null);
+
+            $sku  = trim($sku ?? '');
+            $name = trim($name ?? '');
+
+            if (!$sku || !$name) { $skipped++; continue; }
+            if (Product::where('sku', $sku)->exists()) { $skipped++; continue; }
+
+            Product::create([
+                'sku'            => $sku,
+                'name'           => $name,
+                'description'    => trim($description ?? '') ?: null,
+                'stock_quantity' => max(0, (int) ($stock ?? 0)),
+                'reorder_point'  => max(0, (int) ($reorder ?? 0)),
+            ]);
+            $imported++;
+        }
+
+        fclose($handle);
+
+        return redirect()->route('products.index')
+            ->with('success', "{$imported}件をインポートしました。スキップ: {$skipped}件。");
+    }
+
+    public function reorderList()
+    {
+        $products = Product::belowReorderPoint()->orderBy('stock_quantity', 'asc')->get()
+            ->map(fn($p) => tap($p, fn($p) => $p->order_quantity = max(0, $p->reorder_point * 2 - $p->stock_quantity)));
+        return view('products.reorder-list', compact('products'));
+    }
+
+    public function duplicate(Product $product)
+    {
+        $copy = $product->replicate();
+        $copy->sku = $product->sku . '-copy-' . substr(uniqid(), -4);
+        $copy->name = $product->name . '（コピー）';
+        $copy->stock_quantity = 0;
+        $copy->save();
+        return redirect()->route('products.edit', $copy)->with('success', '商品を複製しました。内容を確認して保存してください。');
+    }
+
+    public function suggest(Request $request)
+    {
+        $q = $request->input('q', '');
+        if (strlen($q) < 1) return response()->json([]);
+        return response()->json(Product::where('sku', 'like', "%{$q}%")->orWhere('name', 'like', "%{$q}%")->orderBy('name')->limit(10)->get(['id', 'sku', 'name']));
+    }
+
+    public function apiSearch(Request $request)
+    {
+        $query = Product::query();
+        if ($request->filled('q')) {
+            $q = $request->input('q');
+            $query->where(fn($sq) => $sq->where('sku', 'like', "%{$q}%")->orWhere('name', 'like', "%{$q}%"));
+        }
+        if ($request->boolean('alert_only')) $query->belowReorderPoint();
+        $products = $query->orderBy('name')->limit(100)->get(['id', 'sku', 'name', 'stock_quantity', 'reorder_point']);
+        return response()->json(['data' => $products, 'total' => $products->count()]);
+    }
+
+    public function apiLowStock()
+    {
+        $products = Product::belowReorderPoint()->orderBy('stock_quantity', 'asc')->get(['id', 'sku', 'name', 'stock_quantity', 'reorder_point']);
+        return response()->json(['data' => $products, 'total' => $products->count()]);
+    }
+}

--- a/resources/views/products/import.blade.php
+++ b/resources/views/products/import.blade.php
@@ -1,0 +1,67 @@
+@extends('layouts.app')
+
+@section('title', 'CSVインポート')
+
+@section('content')
+<div class="d-flex justify-content-between align-items-center mt-4 mb-3">
+    <h2><i class="bi bi-file-earmark-arrow-up me-2"></i>商品CSVインポート</h2>
+    <a href="{{ route('products.index') }}" class="btn btn-outline-secondary">
+        <i class="bi bi-arrow-left me-1"></i>商品一覧に戻る
+    </a>
+</div>
+
+@if(session('success'))
+<div class="alert alert-success alert-dismissible fade show">
+    {{ session('success') }}
+    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+</div>
+@endif
+
+<div class="row">
+    <div class="col-md-6">
+        <div class="card mb-4">
+            <div class="card-header">アップロード</div>
+            <div class="card-body">
+                <form method="POST" action="{{ route('products.import') }}" enctype="multipart/form-data">
+                    @csrf
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold">CSVファイル</label>
+                        <input type="file" name="csv_file" class="form-control @error('csv_file') is-invalid @enderror" accept=".csv,.txt">
+                        @error('csv_file')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-upload me-1"></i>インポート実行
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">ファイル形式</div>
+            <div class="card-body">
+                <p class="text-muted small">ヘッダ行の次の行からデータとして読み込みます。SKUと商品名は必須です。</p>
+                <table class="table table-sm table-bordered">
+                    <thead class="table-light">
+                        <tr>
+                            <th>A列</th><th>B列</th><th>C列</th><th>D列</th><th>E列</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>SKU<span class="text-danger">*</span></td>
+                            <td>商品名<span class="text-danger">*</span></td>
+                            <td>説明</td>
+                            <td>在庫数</td>
+                            <td>発注点</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p class="text-muted small mb-0">既存SKUはスキップされます。在庫数・発注点の省略時は0になります。</p>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Http\Controllers\ProductController;
+use App\Http\Controllers\StockTransactionController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/api/v1/products', [ProductController::class, 'apiSearch'])->name('api.products.search');
+Route::get('/api/v1/products/low-stock', [ProductController::class, 'apiLowStock'])->name('api.products.low-stock');
+
+Route::middleware('auth')->group(function () {
+    Route::get('/', fn() => redirect()->route('products.index'));
+
+    // Static product routes BEFORE resource
+    Route::get('/products/reorder-list', [ProductController::class, 'reorderList'])->name('products.reorder-list');
+    Route::get('/products/suggest', [ProductController::class, 'suggest'])->name('products.suggest');
+    Route::get('/products/import', [ProductController::class, 'importForm'])->name('products.import.form');
+    Route::post('/products/import', [ProductController::class, 'importCsv'])->name('products.import');
+
+    Route::resource('products', ProductController::class);
+
+    Route::get('/products/{product}/qrcode', [ProductController::class, 'qrcode'])->name('products.qrcode');
+    Route::get('/products/{product}/qrcode/download', [ProductController::class, 'qrcodeDownload'])->name('products.qrcode.download');
+    Route::get('/products/{product}/qrcode/download/svg', [ProductController::class, 'qrcodeSvgDownload'])->name('products.qrcode.download.svg');
+    Route::get('/products/{product}/label', [ProductController::class, 'label'])->name('products.label');
+    Route::post('/products/{product}/duplicate', [ProductController::class, 'duplicate'])->name('products.duplicate');
+
+    Route::get('/stock-transactions/export', [StockTransactionController::class, 'export'])->name('stock-transactions.export');
+    Route::get('/stock-transactions/bulk', [StockTransactionController::class, 'bulk'])->name('stock-transactions.bulk');
+    Route::post('/stock-transactions/bulk', [StockTransactionController::class, 'bulkStore'])->name('stock-transactions.bulk.store');
+    Route::get('/stock-transactions', [StockTransactionController::class, 'index'])->name('stock-transactions.index');
+    Route::post('/products/{product}/stock', [StockTransactionController::class, 'store'])->name('stock-transactions.store');
+    Route::post('/products/{product}/quick-adjust', [StockTransactionController::class, 'quickAdjust'])->name('stock-transactions.quick-adjust');
+});


### PR DESCRIPTION
## Summary

- `ProductController::importForm()` / `importCsv()` — file upload endpoint; reads CSV row-by-row with `fgetcsv`, skips the header, skips rows with missing SKU/name or duplicate SKU, creates `Product` records, returns imported/skipped count
- `routes/web.php` — `GET /products/import` and `POST /products/import` before `Route::resource`
- `products/import.blade.php` — upload form + format reference table showing expected column layout

## Test plan

- [ ] Upload a valid CSV — products are created and count shown in success message
- [ ] Upload a CSV with a duplicate SKU row — that row is skipped, others are imported
- [ ] Upload a non-CSV file — validation error is shown


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjEM2ZSQARW5aVzEA72VJN)_