### PR TITLE
feat: extract flash messages into a reusable Blade component

### DIFF
--- a/resources/views/components/flash-messages.blade.php
+++ b/resources/views/components/flash-messages.blade.php
@@ -1,0 +1,25 @@
+@foreach(['success' => 'success', 'error' => 'danger', 'warning' => 'warning', 'info' => 'info'] as $key => $type)
+    @if(session($key))
+    <div class="alert alert-{{ $type }} alert-dismissible fade show mt-3" role="alert">
+        @if($type === 'success')<i class="bi bi-check-circle me-1"></i>@endif
+        @if($type === 'danger')<i class="bi bi-exclamation-circle me-1"></i>@endif
+        @if($type === 'warning')<i class="bi bi-exclamation-triangle me-1"></i>@endif
+        @if($type === 'info')<i class="bi bi-info-circle me-1"></i>@endif
+        {{ session($key) }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    @endif
+@endforeach
+
+@if($errors->any())
+<div class="alert alert-danger alert-dismissible fade show mt-3" role="alert">
+    <i class="bi bi-exclamation-circle me-1"></i>
+    <strong>入力内容を確認してください。</strong>
+    <ul class="mb-0 mt-1">
+        @foreach($errors->all() as $error)
+        <li>{{ $error }}</li>
+        @endforeach
+    </ul>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>
+@endif

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>@yield('title', '在庫管理') - StockManager</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <div class="container">
+        <a class="navbar-brand" href="{{ route('products.index') }}">
+            <i class="bi bi-boxes me-1"></i>StockManager
+        </a>
+        <div class="navbar-nav ms-auto d-flex flex-row gap-3 align-items-center">
+            <a class="nav-link" href="{{ route('products.index') }}">商品一覧</a>
+            <a class="nav-link" href="{{ route('stock-transactions.index') }}">履歴</a>
+            <a class="nav-link" href="{{ route('products.reorder-list') }}">発注リスト</a>
+        </div>
+    </div>
+</nav>
+
+<div class="container">
+    <x-flash-messages />
+    @yield('content')
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+@stack('scripts')
+</body>
+</html>


### PR DESCRIPTION
## Summary

- `components/flash-messages.blade.php` — anonymous component that loops over `success / error / warning / info` session keys and renders dismissible Bootstrap alerts with matching icons; also renders a combined validation error alert when `$errors->any()`
- `layouts/app.blade.php` — replaces per-page `@if(session('success'))` blocks with a single `<x-flash-messages />` call in the layout

## Test plan

- [ ] Perform a stock operation — success alert appears via the layout component (not from view-level code)
- [ ] Trigger a validation error — error list is shown with dismiss button
- [ ] Flash messages auto-dismiss via Bootstrap's `alert-dismissible`


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjEM2ZSQARW5aVzEA72VJN)_