### PR TITLE
fix: guard Accommodation review scores and admin flags from mass assignment

### DIFF
--- a/laravel_project/app/Models/Accommodation.php
+++ b/laravel_project/app/Models/Accommodation.php
@@ -30,6 +30,15 @@ class Accommodation extends Model
         'nearest_station_id',
         'station_distance_minutes',
         'star_rating',
+        'highlight_features',
+        'parking_info',
+        'access_info',
+        'min_price',
+        'max_price',
+        'cancellation_policy_id',
+    ];
+
+    protected $guarded = [
         'review_score',
         'review_count',
         'cleanliness_score',
@@ -37,15 +46,9 @@ class Accommodation extends Model
         'location_score',
         'facility_score',
         'value_score',
-        'highlight_features',
-        'parking_info',
-        'access_info',
-        'min_price',
-        'max_price',
         'is_featured',
         'is_new',
         'display_priority',
-        'cancellation_policy_id',
     ];
 
     protected $casts = [


### PR DESCRIPTION
## Summary

Move computed review aggregate fields and admin display flags from `$fillable` to `$guarded` in the `Accommodation` model.

**Moved to `$guarded`:**
- `review_score`, `review_count` — overall aggregate scores calculated from real reviews
- `cleanliness_score`, `service_score`, `location_score`, `facility_score`, `value_score` — per-dimension review averages
- `is_featured`, `is_new`, `display_priority` — admin-controlled homepage and search ranking flags

## Security Impact

Without this fix, any user with access to an accommodation update endpoint (`PUT /accommodations/{id}`) could POST `review_score=5.0&review_count=9999` to artificially inflate their property's visible rating and review count on the booking platform. Similarly, any authenticated user could set `is_featured=true` to put their property on the homepage, or manipulate `display_priority` to appear at the top of search results.

`getAverageRating()` and `getReviewCount()` already query the database directly — they are unaffected by this change.

## Test plan

- [ ] PUT `/accommodations/{id}` with `review_score=5.0` → confirm score is not updated
- [ ] PUT `/accommodations/{id}` with `is_featured=true` as non-admin → confirm flag is not set
- [ ] Admin-initiated review score recalculation via the service layer still updates scores correctly (uses direct property assignment)
- [ ] Normal accommodation fields (name, address, phone, etc.) remain editable


---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_