### PR TITLE
fix: guard PointTransaction financial fields and validate partyTrend dates

### DIFF
--- a/laravel_project/app/Http/Controllers/ElectionController.php
+++ b/laravel_project/app/Http/Controllers/ElectionController.php
@@ -271,6 +271,11 @@ class ElectionController extends Controller
      */
     public function partyTrend(Request $request, PoliticalParty $party): JsonResponse
     {
+        $request->validate([
+            'start_date' => 'nullable|date|after_or_equal:1900-01-01',
+            'end_date'   => 'nullable|date|after_or_equal:start_date',
+        ]);
+
         $startDate = Carbon::parse($request->input('start_date', '2010-01-01'));
         $endDate = Carbon::parse($request->input('end_date', now()));
 

--- a/laravel_project/app/Models/PointTransaction.php
+++ b/laravel_project/app/Models/PointTransaction.php
@@ -13,12 +13,15 @@ class PointTransaction extends Model
 
     protected $fillable = [
         'customer_id',
-        'type',
-        'points',
-        'balance_after',
         'description',
         'reservation_id',
         'expire_date',
+    ];
+
+    protected $guarded = [
+        'type',
+        'points',
+        'balance_after',
     ];
 
     protected $casts = [
@@ -62,15 +65,17 @@ class PointTransaction extends Model
             $newBalance = $customer->total_points + $points;
             $customer->update(['total_points' => $newBalance]);
 
-            return self::create([
-                'customer_id' => $customerId,
-                'type' => self::TYPE_EARN,
-                'points' => $points,
-                'balance_after' => $newBalance,
-                'description' => $description,
-                'reservation_id' => $reservationId,
-                'expire_date' => $expireDate,
-            ]);
+            $tx = new self();
+            $tx->customer_id = $customerId;
+            $tx->type = self::TYPE_EARN;
+            $tx->points = $points;
+            $tx->balance_after = $newBalance;
+            $tx->description = $description;
+            $tx->reservation_id = $reservationId;
+            $tx->expire_date = $expireDate;
+            $tx->save();
+
+            return $tx;
         });
     }
 
@@ -93,14 +98,16 @@ class PointTransaction extends Model
             $newBalance = $customer->total_points - $points;
             $customer->update(['total_points' => $newBalance]);
 
-            return self::create([
-                'customer_id' => $customerId,
-                'type' => self::TYPE_USE,
-                'points' => -$points,
-                'balance_after' => $newBalance,
-                'description' => $description,
-                'reservation_id' => $reservationId,
-            ]);
+            $tx = new self();
+            $tx->customer_id = $customerId;
+            $tx->type = self::TYPE_USE;
+            $tx->points = -$points;
+            $tx->balance_after = $newBalance;
+            $tx->description = $description;
+            $tx->reservation_id = $reservationId;
+            $tx->save();
+
+            return $tx;
         });
     }
 


### PR DESCRIPTION
## Summary

Two fixes in one PR:

**PointTransaction mass assignment — `app/Models/PointTransaction.php`**
- Move `type`, `points`, and `balance_after` from `$fillable` to `$guarded`
- Convert `earn()` and `use()` static factory methods from `self::create([...])` to direct property assignment + `$tx->save()` so they continue to work after the guard is tightened

**partyTrend() DoS — `ElectionController::partyTrend()`**
- Add `$request->validate()` for `start_date` and `end_date` before passing them to `Carbon::parse()` on this public endpoint

## Security Impact

**PointTransaction**: `balance_after` is the post-transaction loyalty point balance. With it in `$fillable`, any code path that does `PointTransaction::create($request->all())` would let a user set their own balance. `type` being mass-assignable would let a user self-create `TYPE_ADJUST` records. Moving these fields to `$guarded` closes the attack surface.

**partyTrend()**: `GET /parties/{id}/trend?start_date=not-a-date` calls `Carbon::parse('not-a-date')` which throws an unhandled exception, returning a 500 error. On a public endpoint, this is a trivial DoS: no authentication required, one bad request causes an exception.

## Test plan

- [ ] `PointTransaction::create(['balance_after' => 99999])` → confirm `balance_after` is not set
- [ ] `PointTransaction::earn(...)` still creates records with correct `balance_after`
- [ ] `PointTransaction::use(...)` still deducts points and records correct balance
- [ ] `GET /parties/1/trend?start_date=notadate` → expect 422 instead of 500
- [ ] `GET /parties/1/trend?start_date=2020-01-01&end_date=2024-12-31` → expect 200


---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_