### PR TITLE
Fix: Add admin authorization to CustomerController (IDOR/privilege escalation)

### DIFF
--- a/laravel_project/app/Http/Controllers/CustomerController.php
+++ b/laravel_project/app/Http/Controllers/CustomerController.php
@@ -4,22 +4,26 @@ namespace App\Http\Controllers;
 
 use App\Models\Customer;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 
 class CustomerController extends Controller
 {
     public function index()
     {
+        Gate::authorize('admin');
         $customers = Customer::paginate(10);
         return view('customers.index', compact('customers'));
     }
 
     public function create()
     {
+        Gate::authorize('admin');
         return view('customers.create');
     }
 
     public function store(Request $request)
     {
+        Gate::authorize('admin');
         $validated = $request->validate([
             'name' => 'required|string|max:255',
             'email' => 'required|email|unique:customers,email',
@@ -35,17 +39,20 @@ class CustomerController extends Controller
 
     public function show(Customer $customer)
     {
+        Gate::authorize('admin');
         $customer->load('reservations.room.accommodation');
         return view('customers.show', compact('customer'));
     }
 
     public function edit(Customer $customer)
     {
+        Gate::authorize('admin');
         return view('customers.edit', compact('customer'));
     }
 
     public function update(Request $request, Customer $customer)
     {
+        Gate::authorize('admin');
         $validated = $request->validate([
             'name' => 'required|string|max:255',
             'email' => 'required|email|unique:customers,email,' . $customer->id,
@@ -61,6 +68,7 @@ class CustomerController extends Controller
 
     public function destroy(Customer $customer)
     {
+        Gate::authorize('admin');
         $customer->delete();
 
         return redirect()->route('customers.index')


### PR DESCRIPTION
## Summary

- `CustomerController` had no authorization checks on any endpoint
- Any authenticated user could list all customers, view any customer's personal data and reservation history, edit any customer, or delete any customer
- Added `Gate::authorize('admin')` to all seven methods: `index`, `create`, `store`, `show`, `edit`, `update`, `destroy`

## Security Impact

**IDOR + Privilege Escalation**: Customer PII (name, email, phone, address) and full reservation history were readable and writable by any logged-in user. An attacker who registered an account could enumerate all customers and their stays.

## Test plan
- [ ] Non-admin user receives 403 on GET /customers
- [ ] Non-admin user receives 403 on GET /customers/{id}
- [ ] Admin user can access all customer endpoints normally
- [ ] Unauthenticated user is redirected to login (existing auth middleware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_