### PR TITLE
Fix: Admin auth and status escalation in ReservationController

### DIFF
--- a/laravel_project/app/Http/Controllers/ReservationController.php
+++ b/laravel_project/app/Http/Controllers/ReservationController.php
@@ -6,17 +6,20 @@ use App\Models\Reservation;
 use App\Models\Customer;
 use App\Models\Room;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 
 class ReservationController extends Controller
 {
     public function index()
     {
+        Gate::authorize('admin');
         $reservations = Reservation::with('customer', 'room.accommodation')->paginate(10);
         return view('reservations.index', compact('reservations'));
     }
 
     public function create()
     {
+        Gate::authorize('admin');
         $customers = Customer::all();
         $rooms = Room::where('is_available', true)->with('accommodation')->get();
         return view('reservations.create', compact('customers', 'rooms'));
@@ -24,12 +27,13 @@ class ReservationController extends Controller
 
     public function store(Request $request)
     {
+        Gate::authorize('admin');
         $validated = $request->validate([
             'customer_id' => 'required|exists:customers,id',
             'room_id' => 'required|exists:rooms,id',
             'check_in_date' => 'required|date|after_or_equal:today',
             'check_out_date' => 'required|date|after:check_in_date',
-            'status' => 'required|in:pending,confirmed,cancelled,completed',
+            'status' => 'required|in:pending,confirmed',
             'total_amount' => 'required|numeric|min:0',
             'notes' => 'nullable|string',
         ]);
@@ -42,12 +46,14 @@ class ReservationController extends Controller
 
     public function show(Reservation $reservation)
     {
+        Gate::authorize('admin');
         $reservation->load('customer', 'room.accommodation');
         return view('reservations.show', compact('reservation'));
     }
 
     public function edit(Reservation $reservation)
     {
+        Gate::authorize('admin');
         $customers = Customer::all();
         $rooms = Room::with('accommodation')->get();
         return view('reservations.edit', compact('reservation', 'customers', 'rooms'));
@@ -55,6 +61,7 @@ class ReservationController extends Controller
 
     public function update(Request $request, Reservation $reservation)
     {
+        Gate::authorize('admin');
         $validated = $request->validate([
             'customer_id' => 'required|exists:customers,id',
             'room_id' => 'required|exists:rooms,id',
@@ -73,6 +80,7 @@ class ReservationController extends Controller
 
     public function destroy(Reservation $reservation)
     {
+        Gate::authorize('admin');
         $reservation->delete();
 
         return redirect()->route('reservations.index')


### PR DESCRIPTION
## Summary

- All seven reservation endpoints (`index`, `create`, `store`, `show`, `edit`, `update`, `destroy`) had no authorization check — any authenticated user could access or modify any reservation (IDOR)
- `store()` accepted `status` values of `cancelled` and `completed`, allowing a user to create a reservation already in a terminal state (reservation fraud)
- Added `Gate::authorize('admin')` to all methods
- Restricted `store()` status enum to `pending,confirmed` only; `update()` retains full status range for admin transitions

## Security Impact

**IDOR**: Any logged-in user could enumerate all reservations and access customer PII.
**Status manipulation**: An attacker could create reservations pre-marked as `completed`, potentially bypassing billing or loyalty point logic.

## Test plan
- [ ] Non-admin receives 403 on GET /reservations
- [ ] Non-admin receives 403 on POST /reservations with status=completed
- [ ] Admin can create reservation with status=pending or confirmed
- [ ] Admin can update status through full lifecycle (pending→confirmed→completed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_