### PR TITLE
Fix: Add admin authorization to ProductController and StockTransactionController

### DIFF
--- a/laravel_project/app/Http/Controllers/ProductController.php
+++ b/laravel_project/app/Http/Controllers/ProductController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Product;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 use SimpleSoftwareIO\QrCode\Facades\QrCode;
 
 /**
@@ -58,6 +59,7 @@ class ProductController extends Controller
      */
     public function create()
     {
+        Gate::authorize('admin');
         return view('products.create');
     }
 
@@ -66,6 +68,7 @@ class ProductController extends Controller
      */
     public function store(Request $request)
     {
+        Gate::authorize('admin');
         $validated = $request->validate([
             'sku' => ['required', 'string', 'max:100', 'unique:products'],
             'name' => ['required', 'string', 'max:255'],
@@ -98,6 +101,7 @@ class ProductController extends Controller
      */
     public function edit(Product $product)
     {
+        Gate::authorize('admin');
         return view('products.edit', compact('product'));
     }
 
@@ -106,6 +110,7 @@ class ProductController extends Controller
      */
     public function update(Request $request, Product $product)
     {
+        Gate::authorize('admin');
         $validated = $request->validate([
             'sku' => ['required', 'string', 'max:100', 'unique:products,sku,' . $product->id],
             'name' => ['required', 'string', 'max:255'],
@@ -125,6 +130,7 @@ class ProductController extends Controller
      */
     public function destroy(Product $product)
     {
+        Gate::authorize('admin');
         $product->delete();
 
         return redirect()

--- a/laravel_project/app/Http/Controllers/StockTransactionController.php
+++ b/laravel_project/app/Http/Controllers/StockTransactionController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\StockOperationRequest;
 use App\Models\Product;
 use App\Services\StockService;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 
 /**
@@ -25,6 +26,7 @@ class StockTransactionController extends Controller
      */
     public function store(StockOperationRequest $request, Product $product)
     {
+        Gate::authorize('admin');
         try {
             $type = StockTransactionType::from($request->input('type'));
             $quantity = $request->integer('quantity');
@@ -75,6 +77,7 @@ class StockTransactionController extends Controller
      */
     public function index(Request $request)
     {
+        Gate::authorize('admin');
         $query = \App\Models\StockTransaction::query()
             ->with('product');
 


### PR DESCRIPTION
## Summary

- `ProductController` write operations (`create`, `store`, `edit`, `update`, `destroy`) had no authorization — any authenticated user could create, modify, or delete products and directly manipulate inventory metadata
- `StockTransactionController` — both `store` (stock in/out/adjust) and `index` (full audit log) were accessible to any authenticated user
- Added `Gate::authorize('admin')` to all affected methods

## Security Impact

**Unauthorized inventory manipulation**: Any authenticated user could adjust stock quantities, create fake IN transactions, or delete products. The audit log (transaction history) is sensitive business data and should be admin-only.

## Test plan
- [ ] Non-admin user receives 403 on POST /products
- [ ] Non-admin user receives 403 on POST /products/{id}/stock-transactions
- [ ] Non-admin user receives 403 on GET /stock-transactions
- [ ] Admin can perform all inventory operations normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_