### PR TITLE
Fix: DOM XSS via innerHTML with API response data in elections and travel views

### DIFF
--- a/laravel_project/resources/views/elections/show.blade.php
+++ b/laravel_project/resources/views/elections/show.blade.php
@@ -316,22 +316,44 @@ document.getElementById('validateAccuracy')?.addEventListener('click', function(
     .then(response => response.json())
     .then(data => {
         if (data.status === 'success') {
-            let html = '<table class="table table-sm"><thead><tr>';
-            html += '<th>政党</th><th>予測</th><th>実績</th><th>誤差</th><th>範囲内</th></tr></thead><tbody>';
+            const container = document.getElementById('accuracyResults');
+            container.textContent = '';
 
+            const table = document.createElement('table');
+            table.className = 'table table-sm';
+            const thead = document.createElement('thead');
+            const headerRow = document.createElement('tr');
+            ['政党', '予測', '実績', '誤差', '範囲内'].forEach(h => {
+                const th = document.createElement('th');
+                th.textContent = h;
+                headerRow.appendChild(th);
+            });
+            thead.appendChild(headerRow);
+            table.appendChild(thead);
+
+            const tbody = document.createElement('tbody');
             for (const [party, result] of Object.entries(data.data.validation)) {
-                html += `<tr>
-                    <td>${party}</td>
-                    <td>${result.predicted}</td>
-                    <td>${result.actual}</td>
-                    <td>${result.error}</td>
-                    <td>${result.within_range ? '<span class="badge bg-success">Yes</span>' : '<span class="badge bg-danger">No</span>'}</td>
-                </tr>`;
+                const tr = document.createElement('tr');
+                [party, result.predicted, result.actual, result.error].forEach(val => {
+                    const td = document.createElement('td');
+                    td.textContent = val;
+                    tr.appendChild(td);
+                });
+                const tdBadge = document.createElement('td');
+                const badge = document.createElement('span');
+                badge.className = result.within_range ? 'badge bg-success' : 'badge bg-danger';
+                badge.textContent = result.within_range ? 'Yes' : 'No';
+                tdBadge.appendChild(badge);
+                tr.appendChild(tdBadge);
+                tbody.appendChild(tr);
             }
-            html += '</tbody></table>';
-            html += `<p class="text-muted">平均誤差: ${data.data.average_error}議席</p>`;
+            table.appendChild(tbody);
+            container.appendChild(table);
 
-            document.getElementById('accuracyResults').innerHTML = html;
+            const p = document.createElement('p');
+            p.className = 'text-muted';
+            p.textContent = '平均誤差: ' + data.data.average_error + '議席';
+            container.appendChild(p);
         }
         this.disabled = false;
     });
@@ -344,9 +366,10 @@ document.getElementById('addResultModal')?.addEventListener('show.bs.modal', fun
     .then(response => response.json())
     .then(data => {
         const select = this.querySelector('select[name="district_id"]');
-        select.innerHTML = '<option value="">選択してください</option>';
+        select.textContent = '';
+        select.appendChild(new Option('選択してください', ''));
         data.data.forEach(district => {
-            select.innerHTML += `<option value="${district.id}">${district.name}</option>`;
+            select.appendChild(new Option(district.name, district.id));
         });
     });
 
@@ -355,9 +378,10 @@ document.getElementById('addResultModal')?.addEventListener('show.bs.modal', fun
     .then(response => response.json())
     .then(data => {
         const select = this.querySelector('select[name="party_id"]');
-        select.innerHTML = '<option value="">選択してください</option>';
+        select.textContent = '';
+        select.appendChild(new Option('選択してください', ''));
         data.data.forEach(party => {
-            select.innerHTML += `<option value="${party.id}">${party.name}</option>`;
+            select.appendChild(new Option(party.name, party.id));
         });
     });
 });

--- a/laravel_project/resources/views/travel/index.blade.php
+++ b/laravel_project/resources/views/travel/index.blade.php
@@ -267,12 +267,21 @@ keywordInput?.addEventListener('input', function() {
                     return;
                 }
 
-                suggestDropdown.innerHTML = data.data.map(item => `
-                    <a class="dropdown-item" href="#" data-type="${item.type}" data-id="${item.id}" data-name="${item.name}">
-                        <small class="text-muted">${item.type === 'area' ? 'エリア' : '施設'}</small>
-                        ${item.label}
-                    </a>
-                `).join('');
+                suggestDropdown.textContent = '';
+                data.data.forEach(item => {
+                    const a = document.createElement('a');
+                    a.className = 'dropdown-item';
+                    a.href = '#';
+                    a.dataset.type = item.type;
+                    a.dataset.id = item.id;
+                    a.dataset.name = item.name;
+                    const small = document.createElement('small');
+                    small.className = 'text-muted';
+                    small.textContent = item.type === 'area' ? 'エリア' : '施設';
+                    a.appendChild(small);
+                    a.appendChild(document.createTextNode(' ' + item.label));
+                    suggestDropdown.appendChild(a);
+                });
                 suggestDropdown.style.display = 'block';
             });
     }, 300);


### PR DESCRIPTION
## Summary

Two Blade templates used `innerHTML` with raw API response data, creating reflected DOM-based XSS:

### `resources/views/elections/show.blade.php`
- Accuracy validation table built by concatenating party names and result values into an HTML string then setting `innerHTML`
- District and party `<select>` options populated via `innerHTML += \`<option value="${id}">${name}</option>\``

### `resources/views/travel/index.blade.php`
- Search suggestion dropdown built with `innerHTML = data.data.map(item => \`...\`).join('')` where `item.label`, `item.name`, and `item.type` come directly from the API

## Fix

Replaced all unsafe patterns with DOM API:
- `createElement` + `textContent` + `appendChild` for building table rows and anchor elements
- `new Option(text, value)` for populating `<select>` elements
- `document.createTextNode()` for concatenating text content in anchor elements

## Security Impact

If the backend API returns attacker-controlled values (e.g., a party name containing `<script>`) or if a MITM/compromised API endpoint is used, arbitrary JavaScript would execute in the user's browser.

## Test plan
- [ ] Accuracy results table renders correctly with normal data
- [ ] District/party selects populate correctly in the add result modal
- [ ] Travel search suggestion dropdown renders correctly
- [ ] A party name containing `<b>bold</b>` renders as literal text, not HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_