### PR TITLE
Fix: Protect Product.stock_quantity from mass assignment to preserve audit trail

### DIFF
--- a/laravel_project/app/Http/Controllers/ProductController.php
+++ b/laravel_project/app/Http/Controllers/ProductController.php
@@ -74,7 +74,9 @@ class ProductController extends Controller
             'reorder_point' => ['required', 'integer', 'min:0'],
         ]);
 
-        Product::create($validated);
+        $product = Product::create($validated);
+        $product->stock_quantity = $validated['stock_quantity'];
+        $product->save();
 
         return redirect()
             ->route('products.index')

--- a/laravel_project/app/Models/Product.php
+++ b/laravel_project/app/Models/Product.php
@@ -17,9 +17,12 @@ class Product extends Model
         'sku',
         'name',
         'description',
-        'stock_quantity',
         'reorder_point',
         'warehouse_id',
+    ];
+
+    protected $guarded = [
+        'stock_quantity',
     ];
 
     protected $casts = [


### PR DESCRIPTION
## Summary

- `stock_quantity` was in `Product::$fillable`, which allowed any mass-assignment code path to bypass `StockService` and modify stock counts without creating an audit transaction
- The model docblock explicitly states: "stock_quantity は非正規化して持つが、必ず stock_transactions から復元可能にする (Single Source of Truth)"
- Moved `stock_quantity` to `$guarded` to enforce the invariant
- Updated `ProductController::store()` to set it directly after `create()` for initial stock-on-hand (a `StockTransaction` record for initial inventory is not created here, consistent with the existing behavior)

## Security Impact

Any code doing `Product::create($data)` or `$product->update($data)` where `$data` contains `stock_quantity` would silently alter inventory without a trace in the transaction log, making the audit trail untrustworthy.

## Test plan
- [ ] Creating a new product with initial stock quantity works correctly
- [ ] Stock in/out/adjust via StockService still updates `stock_quantity` correctly (uses direct property assignment internally)
- [ ] Passing `stock_quantity` in update request body has no effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_