### PR TITLE
Fix: Add admin authorization and remove request injection in PaymentController

### DIFF
--- a/laravel_project/app/Http/Controllers/PaymentController.php
+++ b/laravel_project/app/Http/Controllers/PaymentController.php
@@ -6,6 +6,7 @@ use App\Models\Payment;
 use App\Models\Reservation;
 use App\Services\PaymentService;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
 
 class PaymentController extends Controller
@@ -22,6 +23,7 @@ class PaymentController extends Controller
      */
     public function index()
     {
+        Gate::authorize('admin');
         $payments = Payment::with(['reservation.customer', 'reservation.room'])
             ->orderBy('created_at', 'desc')
             ->paginate(20);
@@ -36,6 +38,7 @@ class PaymentController extends Controller
      */
     public function create(Request $request)
     {
+        Gate::authorize('admin');
         $request->validate([
             'reservation_id' => 'nullable|integer|exists:reservations,id',
         ]);
@@ -51,6 +54,7 @@ class PaymentController extends Controller
      */
     public function store(Request $request)
     {
+        Gate::authorize('admin');
         $validated = $request->validate([
             'reservation_id' => 'required|exists:reservations,id',
             'amount' => 'required|numeric|min:0',
@@ -62,9 +66,8 @@ class PaymentController extends Controller
         try {
             $payment = $this->paymentService->createPayment($validated);
 
-            // 決済処理を実行
-            if ($request->has('process_now') && $request->input('process_now')) {
-                $this->paymentService->processPayment($payment, $request->all());
+            if ($request->boolean('process_now')) {
+                $this->paymentService->processPayment($payment);
             }
 
             return redirect()->route('payments.show', $payment)
@@ -79,6 +82,7 @@ class PaymentController extends Controller
      */
     public function show(Payment $payment)
     {
+        Gate::authorize('admin');
         $payment->load(['reservation.customer', 'reservation.room']);
         return Inertia::render('Payments/Show', [
             'payment' => $payment,
@@ -90,6 +94,7 @@ class PaymentController extends Controller
      */
     public function process(Payment $payment)
     {
+        Gate::authorize('admin');
         try {
             $this->paymentService->processPayment($payment);
 
@@ -105,6 +110,7 @@ class PaymentController extends Controller
      */
     public function refund(Request $request, Payment $payment)
     {
+        Gate::authorize('admin');
         $validated = $request->validate([
             'amount' => 'nullable|numeric|min:0|max:' . $payment->amount,
             'reason' => 'nullable|string',
@@ -129,6 +135,7 @@ class PaymentController extends Controller
      */
     public function cancel(Payment $payment)
     {
+        Gate::authorize('admin');
         try {
             $this->paymentService->cancelPayment($payment);
 
@@ -144,6 +151,7 @@ class PaymentController extends Controller
      */
     public function checkStatus(Reservation $reservation)
     {
+        Gate::authorize('admin');
         $status = $this->paymentService->checkPaymentStatus($reservation);
 
         return view('payments.status', compact('reservation', 'status'));


### PR DESCRIPTION
## Summary

Two issues fixed in `PaymentController`:

### 1. Missing authorization (IDOR / privilege escalation)
All seven endpoints — `index`, `create`, `store`, `show`, `process`, `refund`, `cancel`, `checkStatus` — had no authorization check. Any authenticated user could view all payment records, create payments for any reservation, trigger refunds, or cancel payments.

### 2. Unvalidated request data passed to payment service
`store()` called `$this->paymentService->processPayment($payment, $request->all())`, passing the full raw request bag to the payment service. Depending on how the service uses that data, this could allow parameter injection (e.g., overriding `amount`, `transaction_id`, or `status` fields).

## Fix
- Added `Gate::authorize('admin')` to all methods
- Removed the `$request->all()` argument from `processPayment()` — the service's no-arg variant already has access to all payment data it needs from the `$payment` model
- Used `$request->boolean('process_now')` instead of `$request->has()` + `$request->input()` for the conditional

## Test plan
- [ ] Non-admin user receives 403 on GET /payments
- [ ] Non-admin user receives 403 on POST /payments/{id}/refund
- [ ] Admin can process and refund payments normally
- [ ] `process_now` flag still triggers immediate processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_