### PR TITLE
Fix: Add admin authorization to AccommodationController and RoomController

### DIFF
--- a/laravel_project/app/Http/Controllers/AccommodationController.php
+++ b/laravel_project/app/Http/Controllers/AccommodationController.php
@@ -4,22 +4,26 @@ namespace App\Http\Controllers;
 
 use App\Models\Accommodation;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 
 class AccommodationController extends Controller
 {
     public function index()
     {
+        Gate::authorize('admin');
         $accommodations = Accommodation::with('rooms')->paginate(10);
         return view('accommodations.index', compact('accommodations'));
     }
 
     public function create()
     {
+        Gate::authorize('admin');
         return view('accommodations.create');
     }
 
     public function store(Request $request)
     {
+        Gate::authorize('admin');
         $validated = $request->validate([
             'name' => 'required|string|max:255',
             'address' => 'required|string',
@@ -36,17 +40,20 @@ class AccommodationController extends Controller
 
     public function show(Accommodation $accommodation)
     {
+        Gate::authorize('admin');
         $accommodation->load('rooms');
         return view('accommodations.show', compact('accommodation'));
     }
 
     public function edit(Accommodation $accommodation)
     {
+        Gate::authorize('admin');
         return view('accommodations.edit', compact('accommodation'));
     }
 
     public function update(Request $request, Accommodation $accommodation)
     {
+        Gate::authorize('admin');
         $validated = $request->validate([
             'name' => 'required|string|max:255',
             'address' => 'required|string',
@@ -63,6 +70,7 @@ class AccommodationController extends Controller
 
     public function destroy(Accommodation $accommodation)
     {
+        Gate::authorize('admin');
         $accommodation->delete();
 
         return redirect()->route('accommodations.index')

--- a/laravel_project/app/Http/Controllers/RoomController.php
+++ b/laravel_project/app/Http/Controllers/RoomController.php
@@ -5,23 +5,27 @@ namespace App\Http\Controllers;
 use App\Models\Room;
 use App\Models\Accommodation;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 
 class RoomController extends Controller
 {
     public function index()
     {
+        Gate::authorize('admin');
         $rooms = Room::with('accommodation')->paginate(10);
         return view('rooms.index', compact('rooms'));
     }
 
     public function create()
     {
+        Gate::authorize('admin');
         $accommodations = Accommodation::all();
         return view('rooms.create', compact('accommodations'));
     }
 
     public function store(Request $request)
     {
+        Gate::authorize('admin');
         $validated = $request->validate([
             'accommodation_id' => 'required|exists:accommodations,id',
             'room_number' => 'required|string|max:255',
@@ -40,18 +44,21 @@ class RoomController extends Controller
 
     public function show(Room $room)
     {
+        Gate::authorize('admin');
         $room->load('accommodation', 'reservations');
         return view('rooms.show', compact('room'));
     }
 
     public function edit(Room $room)
     {
+        Gate::authorize('admin');
         $accommodations = Accommodation::all();
         return view('rooms.edit', compact('room', 'accommodations'));
     }
 
     public function update(Request $request, Room $room)
     {
+        Gate::authorize('admin');
         $validated = $request->validate([
             'accommodation_id' => 'required|exists:accommodations,id',
             'room_number' => 'required|string|max:255',
@@ -70,6 +77,7 @@ class RoomController extends Controller
 
     public function destroy(Room $room)
     {
+        Gate::authorize('admin');
         $room->delete();
 
         return redirect()->route('rooms.index')


### PR DESCRIPTION
## Summary

- `AccommodationController` and `RoomController` had no authorization checks on any endpoint
- Any authenticated user could list all accommodations and rooms, create new facilities, modify room pricing (`price_per_night`), toggle availability (`is_available`), change capacity, or delete rooms and entire accommodation records
- Added `Gate::authorize('admin')` to all methods in both controllers

## Security Impact

**Unauthorized facility manipulation**: A non-admin could set `is_available = false` on all rooms to block bookings, change room pricing to 0 to book at no cost, or delete accommodation records entirely.

## Test plan
- [ ] Non-admin user receives 403 on GET /accommodations
- [ ] Non-admin user receives 403 on POST /rooms (create room)
- [ ] Non-admin user receives 403 on PATCH /rooms/{id} (change pricing/availability)
- [ ] Admin can manage accommodations and rooms normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_