### PR TITLE
Fix: Require auth middleware on travel booking, travel favorites, and event favorites routes

### DIFF
--- a/laravel_project/routes/web.php
+++ b/laravel_project/routes/web.php
@@ -81,14 +81,18 @@ Route::get('/travel/accommodations/{id}', [TravelController::class, 'show'])->na
 Route::get('/travel/accommodations/{id}/plans', [TravelController::class, 'searchPlans'])->name('travel.plans');
 Route::get('/travel/accommodations/{id}/reviews', [TravelController::class, 'reviews'])->name('travel.reviews');
 
-// 予約フロー
-Route::get('/travel/booking/{plan}', [TravelController::class, 'booking'])->name('travel.booking');
-Route::post('/travel/booking/confirm', [TravelController::class, 'confirmBooking'])->name('travel.booking.confirm');
-Route::post('/travel/booking/complete', [TravelController::class, 'completeBooking'])->name('travel.booking.complete');
+// 予約フロー (認証必須)
+Route::middleware('auth')->group(function () {
+    Route::get('/travel/booking/{plan}', [TravelController::class, 'booking'])->name('travel.booking');
+    Route::post('/travel/booking/confirm', [TravelController::class, 'confirmBooking'])->name('travel.booking.confirm');
+    Route::post('/travel/booking/complete', [TravelController::class, 'completeBooking'])->name('travel.booking.complete');
+});
 
-// お気に入り
-Route::post('/travel/favorites', [TravelController::class, 'addFavorite'])->name('travel.favorites.add');
-Route::delete('/travel/favorites/{accommodation}', [TravelController::class, 'removeFavorite'])->name('travel.favorites.remove');
+// お気に入り (認証必須)
+Route::middleware('auth')->group(function () {
+    Route::post('/travel/favorites', [TravelController::class, 'addFavorite'])->name('travel.favorites.add');
+    Route::delete('/travel/favorites/{accommodation}', [TravelController::class, 'removeFavorite'])->name('travel.favorites.remove');
+});
 
 // エリアAPI
 Route::get('/travel/areas', [TravelController::class, 'areas'])->name('travel.areas');
@@ -103,10 +107,12 @@ Route::get('/events/calendar', [EventController::class, 'calendar'])->name('even
 // イベント詳細
 Route::get('/events/{id}', [EventController::class, 'show'])->name('events.show');
 
-// お気に入り
-Route::get('/events/my/favorites', [EventController::class, 'favorites'])->name('events.favorites');
-Route::post('/events/favorites', [EventController::class, 'addFavorite'])->name('events.favorites.add');
-Route::delete('/events/favorites/{eventId}', [EventController::class, 'removeFavorite'])->name('events.favorites.remove');
+// お気に入り (認証必須)
+Route::middleware('auth')->group(function () {
+    Route::get('/events/my/favorites', [EventController::class, 'favorites'])->name('events.favorites');
+    Route::post('/events/favorites', [EventController::class, 'addFavorite'])->name('events.favorites.add');
+    Route::delete('/events/favorites/{eventId}', [EventController::class, 'removeFavorite'])->name('events.favorites.remove');
+});
 
 // API
 Route::get('/api/events/search', [EventController::class, 'apiSearch'])->name('events.api.search');


### PR DESCRIPTION
## Summary

Three route groups were accessible without authentication:

### Travel booking (`/travel/booking/*`)
- `GET /travel/booking/{plan}` — booking form
- `POST /travel/booking/confirm` — booking confirmation
- `POST /travel/booking/complete` — complete booking and create reservation

An unauthenticated user could complete the full booking flow and create reservations without a user account.

### Travel favorites (`/travel/favorites`)
- `POST /travel/favorites` — add accommodation to favorites
- `DELETE /travel/favorites/{accommodation}` — remove favorite

### Event favorites (`/events/my/favorites`, `/events/favorites`)
- `GET /events/my/favorites` — view favorites list
- `POST /events/favorites` — add event to favorites
- `DELETE /events/favorites/{eventId}` — remove favorite

## Fix

Wrapped all three route groups in `Route::middleware('auth')->group(...)`.

## Test plan
- [ ] Unauthenticated user accessing `/travel/booking/{plan}` is redirected to login
- [ ] Unauthenticated POST to `/travel/booking/complete` is rejected with 302 to login
- [ ] Unauthenticated POST to `/events/favorites` is rejected
- [ ] Authenticated users can access all endpoints normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_