### PR TITLE
Fix: Guard Payment financial and status fields from mass assignment

### DIFF
--- a/laravel_project/app/Models/Payment.php
+++ b/laravel_project/app/Models/Payment.php
@@ -14,16 +14,19 @@ class Payment extends Model
         'reservation_id',
         'amount',
         'payment_method',
-        'status',
-        'transaction_id',
         'payment_gateway',
         'payment_details',
+        'refund_reason',
+        'notes',
+    ];
+
+    protected $guarded = [
+        'status',
+        'transaction_id',
         'paid_at',
         'refunded_at',
         'refund_amount',
-        'refund_reason',
         'failure_reason',
-        'notes',
     ];
 
     protected $casts = [
@@ -47,11 +50,10 @@ class Payment extends Model
      */
     public function markAsPaid(string $transactionId = null): void
     {
-        $this->update([
-            'status' => 'completed',
-            'paid_at' => now(),
-            'transaction_id' => $transactionId ?? $this->transaction_id,
-        ]);
+        $this->status = 'completed';
+        $this->paid_at = now();
+        $this->transaction_id = $transactionId ?? $this->transaction_id;
+        $this->save();
     }
 
     /**
@@ -59,10 +61,9 @@ class Payment extends Model
      */
     public function markAsFailed(string $reason): void
     {
-        $this->update([
-            'status' => 'failed',
-            'failure_reason' => $reason,
-        ]);
+        $this->status = 'failed';
+        $this->failure_reason = $reason;
+        $this->save();
     }
 
     /**
@@ -70,14 +71,11 @@ class Payment extends Model
      */
     public function refund(float $amount = null, string $reason = null): void
     {
-        $refundAmount = $amount ?? $this->amount;
-
-        $this->update([
-            'status' => 'refunded',
-            'refunded_at' => now(),
-            'refund_amount' => $refundAmount,
-            'refund_reason' => $reason,
-        ]);
+        $this->status = 'refunded';
+        $this->refunded_at = now();
+        $this->refund_amount = $amount ?? $this->amount;
+        $this->refund_reason = $reason;
+        $this->save();
     }
 
     /**


### PR DESCRIPTION
## Summary

`Payment::$fillable` included six fields that should only ever be set by the payment gateway integration or internal workflow methods — not via mass assignment from request data:

| Field | Risk |
|---|---|
| `status` | Forge a `completed` payment without processing |
| `transaction_id` | Spoof a gateway transaction reference |
| `paid_at` | Backdate payment timestamps |
| `refunded_at` | Backdate refund timestamps |
| `refund_amount` | Inflate refund amount beyond what was paid |
| `failure_reason` | Set arbitrary failure text |

## Fix

- Moved all six fields to `$guarded`
- Converted `markAsPaid()`, `markAsFailed()`, and `refund()` from `$this->update([...])` to direct property assignment + `$this->save()` so they continue to work against guarded fields

## Security Impact

Any code path that did `Payment::create($request->input())` or `$payment->update($request->all())` could previously mark a payment as completed without touching the payment gateway.

## Test plan
- [ ] `markAsPaid('txn_123')` correctly sets status=completed, transaction_id, paid_at
- [ ] `markAsFailed('insufficient funds')` correctly sets status=failed, failure_reason
- [ ] `refund(500.00, 'partial refund')` correctly sets status=refunded, amounts, timestamps
- [ ] Passing `status=completed` in a create/update request body has no effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_