### PR TITLE
Guard Reservation system-managed fields from mass assignment

### DIFF
--- a/laravel_project/app/Models/Reservation.php
+++ b/laravel_project/app/Models/Reservation.php
@@ -36,15 +36,18 @@ class Reservation extends Model
         'check_in_date',
         'check_out_date',
         'status',
-        'payment_status',
-        'actual_check_in_time',
-        'actual_check_out_time',
         'total_amount',
         'applied_discounts',
         'price_breakdown',
-        'cancelled_at',
         'cancellation_reason',
         'notes',
+    ];
+
+    protected $guarded = [
+        'payment_status',
+        'actual_check_in_time',
+        'actual_check_out_time',
+        'cancelled_at',
         'created_by_user_id',
         'updated_by_user_id',
     ];


### PR DESCRIPTION
## Summary

- Move system-managed fields (`payment_status`, `actual_check_in_time`, `actual_check_out_time`, `cancelled_at`, `created_by_user_id`, `updated_by_user_id`) from `$fillable` to `$guarded` in `Reservation` model
- These fields are set exclusively by internal workflow methods (`changeStatus`, `checkIn`, `checkOut`) and must not be mass-assignable via user input

## Security Fix

Previously, any controller passing `$request->all()` or user-controlled arrays to `Reservation::create()`/`update()` could overwrite audit timestamps, payment status, and user attribution fields. Guarding these fields prevents that class of mass-assignment attack.

## Test plan
- [ ] Reservation creation via `ReservationController::store()` still works with allowed fields
- [ ] `checkIn()` / `checkOut()` / `changeStatus()` internal methods continue to set guarded fields correctly (they use direct property assignment, not `update([...])`)
- [ ] Attempting to mass-assign `payment_status` via HTTP request is silently ignored

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_