### PR TITLE
Restrict customer API to admin role and add rate limiting

### DIFF
--- a/laravel_project/routes/api.php
+++ b/laravel_project/routes/api.php
@@ -19,8 +19,8 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-// 顧客API (認証必須)
-Route::middleware('auth:sanctum')->prefix('customers')->group(function () {
+// 顧客API (管理者のみ・レート制限付き)
+Route::middleware(['auth:sanctum', 'can:admin', 'throttle:30,1'])->prefix('customers')->group(function () {
     // 顧客一覧取得
     Route::get('/', function (Request $request) {
         $validated = $request->validate([


### PR DESCRIPTION
## Summary

- Add `can:admin` middleware to the customer API route group so only admin users can access customer data via the API
- Add `throttle:30,1` rate limiting (30 requests/minute) to prevent brute-force enumeration

## Security Fix

**Before:** Any Sanctum-authenticated user could list, read, create, update, and delete all customer records via `GET/POST/PUT/DELETE /api/customers`. This is a privilege escalation vulnerability — regular users should never have access to the full customer database.

**After:** The route group requires `['auth:sanctum', 'can:admin', 'throttle:30,1']`. Only users with the `admin` Gate permission can access these endpoints, and requests are capped at 30/minute.

## Test plan
- [ ] Admin user can list and manage customers via the API
- [ ] Non-admin authenticated user receives 403 on all `/api/customers` endpoints
- [ ] Unauthenticated request receives 401
- [ ] More than 30 requests/minute from a single client are rejected with 429

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_