### PR TITLE
Guard admin-only Review fields from mass assignment

### DIFF
--- a/laravel_project/app/Models/Review.php
+++ b/laravel_project/app/Models/Review.php
@@ -25,6 +25,9 @@ class Review extends Model
         'comment',
         'photos',
         'is_verified',
+    ];
+
+    protected $guarded = [
         'is_published',
         'admin_response',
         'admin_responded_at',
@@ -102,7 +105,8 @@ class Review extends Model
      */
     public function publish(): void
     {
-        $this->update(['is_published' => true]);
+        $this->is_published = true;
+        $this->save();
     }
 
     /**
@@ -110,7 +114,8 @@ class Review extends Model
      */
     public function unpublish(): void
     {
-        $this->update(['is_published' => false]);
+        $this->is_published = false;
+        $this->save();
     }
 
     /**
@@ -118,7 +123,8 @@ class Review extends Model
      */
     public function verify(): void
     {
-        $this->update(['is_verified' => true]);
+        $this->is_verified = true;
+        $this->save();
     }
 
     /**
@@ -126,10 +132,9 @@ class Review extends Model
      */
     public function addAdminResponse(string $response): void
     {
-        $this->update([
-            'admin_response' => $response,
-            'admin_responded_at' => now(),
-        ]);
+        $this->admin_response = $response;
+        $this->admin_responded_at = now();
+        $this->save();
     }
 
     /**


### PR DESCRIPTION
## Summary

- Move `is_published`, `admin_response`, `admin_responded_at`, `helpful_count` from `$fillable` to `$guarded` in `Review` model
- Convert internal methods (`publish`, `unpublish`, `verify`, `addAdminResponse`) from `$this->update([...])` to direct property assignment so they continue to work with guarded fields

## Security Fix

These four fields control the public visibility of a review and its admin response — they must never be settable by end-user input. With them in `$fillable`, any controller carelessly passing `$request->all()` or `$model->fill($request->all())` would allow:
- Setting `is_published = false` to suppress a legitimate negative review
- Injecting arbitrary `admin_response` text impersonating hotel management
- Manipulating `helpful_count` vote tallies

## Test plan
- [ ] `Review::create([...])` with user-supplied fields works for the allowed set
- [ ] Passing `is_published`, `admin_response`, or `helpful_count` via mass assignment is silently ignored
- [ ] `$review->publish()` / `unpublish()` / `addAdminResponse()` still function correctly via direct assignment

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_