### PR TITLE
Add admin Gate definition and is_admin column to users (prerequisite for all admin auth PRs)

### DIFF
--- a/laravel_project/app/Models/User.php
+++ b/laravel_project/app/Models/User.php
@@ -38,11 +38,14 @@ class User extends Authenticatable
      *
      * @return array<string, string>
      */
+    protected $guarded = ['is_admin'];
+
     protected function casts(): array
     {
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'is_admin' => 'boolean',
         ];
     }
 }

--- a/laravel_project/app/Providers/AppServiceProvider.php
+++ b/laravel_project/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +20,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Gate::define('admin', fn ($user) => (bool) $user->is_admin);
     }
 }

--- a/laravel_project/database/migrations/2026_07_20_000001_add_is_admin_to_users_table.php
+++ b/laravel_project/database/migrations/2026_07_20_000001_add_is_admin_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_admin')->default(false)->after('email_verified_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_admin');
+        });
+    }
+};


### PR DESCRIPTION
## Summary

- Add `is_admin` boolean column to the `users` table (default `false`) via migration
- Guard `is_admin` on the `User` model to prevent privilege escalation via mass assignment
- Define the `admin` Gate in `AppServiceProvider` so `Gate::authorize('admin')` works across the codebase

## Why This PR Is Critical

Every other security PR in this series adds `Gate::authorize('admin')` to controller methods. Without a Gate named `admin` being defined, those calls either throw a runtime `AuthorizationException` (blocking everyone including real admins) or silently fail. This PR is the **foundation** that makes all other admin-restriction PRs functional.

## Security Fix

**Privilege escalation via mass assignment**: `is_admin` is placed in `$guarded` (not `$fillable`) so no controller can elevate a user to admin via `$request->all()` or `User::create([..., 'is_admin' => true, ...])`.

**Privilege escalation via unregistered Gate**: The Gate definition ensures `can:admin` and `Gate::authorize('admin')` use the database-backed `is_admin` flag — not some implicit always-allow fallback.

## Test plan
- [ ] Migration runs cleanly: `php artisan migrate`
- [ ] New users default to `is_admin = false`
- [ ] `Gate::allows('admin')` returns `true` only for users with `is_admin = true`
- [ ] `Gate::authorize('admin')` on a non-admin user throws 403
- [ ] Attempting `User::create(['is_admin' => true, ...])` silently ignores `is_admin`

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_