### PR TITLE
Add SecurityHeaders middleware to prevent clickjacking and MIME sniffing

### DIFF
--- a/laravel_project/app/Http/Middleware/SecurityHeaders.php
+++ b/laravel_project/app/Http/Middleware/SecurityHeaders.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SecurityHeaders
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        $response->headers->set('X-Frame-Options', 'SAMEORIGIN');
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('X-XSS-Protection', '1; mode=block');
+        $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
+        $response->headers->set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+
+        return $response;
+    }
+}

--- a/laravel_project/bootstrap/app.php
+++ b/laravel_project/bootstrap/app.php
@@ -12,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->web(append: [
+            \App\Http\Middleware\SecurityHeaders::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //


### PR DESCRIPTION
## Summary

- Create `App\Http\Middleware\SecurityHeaders` that injects security response headers
- Register it as a global web middleware in `bootstrap/app.php` so all web responses include it

## Security Headers Added

| Header | Value | Protection |
|---|---|---|
| `X-Frame-Options` | `SAMEORIGIN` | Prevents clickjacking via iframe embedding from other origins |
| `X-Content-Type-Options` | `nosniff` | Prevents browsers from MIME-sniffing responses away from declared content-type |
| `X-XSS-Protection` | `1; mode=block` | Enables legacy browser XSS filter (defense-in-depth for older browsers) |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Limits referrer information sent to cross-origin requests |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | Prevents the page from requesting sensitive browser features |

## Test plan
- [ ] All web route responses include the new headers (verify with browser DevTools or `curl -I`)
- [ ] API routes (`/api/*`) are not affected — middleware is web-only
- [ ] No existing functionality is broken

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_