### PR TITLE
Add max length constraints to unbounded free-text fields

### DIFF
--- a/laravel_project/app/Http/Controllers/ElectionController.php
+++ b/laravel_project/app/Http/Controllers/ElectionController.php
@@ -249,7 +249,7 @@ class ElectionController extends Controller
             'response_rate' => 'nullable|numeric|min:0|max:100',
             'demographic_breakdown' => 'nullable|array',
             'regional_breakdown' => 'nullable|array',
-            'notes' => 'nullable|string',
+            'notes' => 'nullable|string|max:2000',
         ]);
 
         $pollData = PollData::create($validated);
@@ -364,7 +364,7 @@ class ElectionController extends Controller
             'voter_turnout' => 'nullable|numeric|min:0|max:100',
             'total_voters' => 'nullable|integer|min:0',
             'total_votes' => 'nullable|integer|min:0',
-            'notes' => 'nullable|string',
+            'notes' => 'nullable|string|max:2000',
         ]);
 
         $election = Election::create($validated);
@@ -390,7 +390,7 @@ class ElectionController extends Controller
             'seats_won' => 'required|integer|min:0',
             'is_winner' => 'boolean',
             'rank' => 'nullable|integer|min:1',
-            'notes' => 'nullable|string',
+            'notes' => 'nullable|string|max:2000',
         ]);
 
         $result = $election->results()->create($validated);

--- a/laravel_project/app/Http/Controllers/PaymentController.php
+++ b/laravel_project/app/Http/Controllers/PaymentController.php
@@ -55,8 +55,8 @@ class PaymentController extends Controller
             'reservation_id' => 'required|exists:reservations,id',
             'amount' => 'required|numeric|min:0',
             'payment_method' => 'required|in:credit_card,bank_transfer,cash,digital_wallet',
-            'payment_gateway' => 'nullable|string',
-            'notes' => 'nullable|string',
+            'payment_gateway' => 'nullable|string|max:100',
+            'notes' => 'nullable|string|max:2000',
         ]);
 
         try {

--- a/laravel_project/app/Http/Controllers/ReservationController.php
+++ b/laravel_project/app/Http/Controllers/ReservationController.php
@@ -31,7 +31,7 @@ class ReservationController extends Controller
             'check_out_date' => 'required|date|after:check_in_date',
             'status' => 'required|in:pending,confirmed,cancelled,completed',
             'total_amount' => 'required|numeric|min:0',
-            'notes' => 'nullable|string',
+            'notes' => 'nullable|string|max:2000',
         ]);
 
         Reservation::create($validated);
@@ -62,7 +62,7 @@ class ReservationController extends Controller
             'check_out_date' => 'required|date|after:check_in_date',
             'status' => 'required|in:pending,confirmed,cancelled,completed',
             'total_amount' => 'required|numeric|min:0',
-            'notes' => 'nullable|string',
+            'notes' => 'nullable|string|max:2000',
         ]);
 
         $reservation->update($validated);

--- a/laravel_project/app/Http/Controllers/TravelController.php
+++ b/laravel_project/app/Http/Controllers/TravelController.php
@@ -211,7 +211,7 @@ class TravelController extends Controller
             'name_kana' => 'required|string|max:100',
             'email' => 'required|email',
             'phone' => 'required|string|max:20',
-            'arrival_time' => 'required|string',
+            'arrival_time' => 'required|string|max:50',
             'special_requests' => 'nullable|string|max:1000',
             'payment_method' => 'required|in:on_site,credit_card',
         ]);
@@ -247,7 +247,7 @@ class TravelController extends Controller
             'name_kana' => 'required|string|max:100',
             'email' => 'required|email',
             'phone' => 'required|string|max:20',
-            'arrival_time' => 'required|string',
+            'arrival_time' => 'required|string|max:50',
             'special_requests' => 'nullable|string|max:1000',
             'payment_method' => 'required|in:on_site,credit_card',
         ]);


### PR DESCRIPTION
## Summary

- Cap all `'nullable|string'` fields that lacked `max:` constraints across four controllers
- Affected controllers: `ElectionController`, `PaymentController`, `ReservationController`, `TravelController`

## Security Fix

Free-text fields without a maximum length allow clients to send arbitrarily large payloads. This can cause:
- Database column overflow / silent truncation
- Memory exhaustion during validation or storage
- Log flooding if field values are logged on error

Fields fixed:

| Controller | Field | Old | New |
|---|---|---|---|
| ElectionController | `notes` (×3) | `nullable\|string` | `nullable\|string\|max:2000` |
| PaymentController | `notes` | `nullable\|string` | `nullable\|string\|max:2000` |
| PaymentController | `payment_gateway` | `nullable\|string` | `nullable\|string\|max:100` |
| ReservationController | `notes` (×2) | `nullable\|string` | `nullable\|string\|max:2000` |
| TravelController | `arrival_time` (×2) | `required\|string` | `required\|string\|max:50` |

## Test plan
- [ ] Normal-length values still pass validation
- [ ] Submitting a string longer than the cap returns a 422 validation error
- [ ] No existing functionality is broken

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_