### PR TITLE
Guard web_additional.php test routes behind environment check

### DIFF
--- a/laravel_project/routes/web_additional.php
+++ b/laravel_project/routes/web_additional.php
@@ -2,6 +2,12 @@
 
 // ===== 新機能のテスト用ルート =====
 // このファイルのルートを web.php に追加してください
+// IMPORTANT: This file must only be included in local/testing environments.
+// These routes create and modify real database records (payments, refunds, reviews).
+
+if (!app()->environment('local', 'testing')) {
+    return;
+}
 
 // 決済テスト
 Route::get('/test-payment', function (PaymentService $paymentService) {


### PR DESCRIPTION
## Summary

- Add `if (!app()->environment('local', 'testing')) { return; }` guard at the top of `routes/web_additional.php`

## Security Fix

`web_additional.php` contains test routes that:
- `POST /test-payment` — creates a real payment and processes it
- `GET /test-refund` — refunds the first completed payment found
- `GET /test-review` — modifies reservation status to `checked_out` and creates a review
- `GET /test-report` — returns full business report data

These are unauthenticated `GET` routes with no authorization checks. If the file is ever `include`d in `web.php` (as the comment at the top suggests), and `APP_ENV` is not set to `local`/`testing`, anyone could trigger payment processing, refunds, and data mutations via simple browser requests.

The same environment guard pattern already used in `routes/web.php` (line 152) is now applied here so the file safely exits if included in a non-local context.

## Test plan
- [ ] Test routes still register and function in `local` environment
- [ ] File exits immediately and registers no routes when `APP_ENV=production`

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_