### PR TITLE
security: prevent exception message disclosure in ElectionDataService

### DIFF
--- a/laravel_project/app/Services/ElectionDataService.php
+++ b/laravel_project/app/Services/ElectionDataService.php
@@ -71,7 +71,7 @@ class ElectionDataService
             DB::beginTransaction();
 
             if (!file_exists($filePath)) {
-                throw new \Exception("ファイルが見つかりません: {$filePath}");
+                throw new \Exception("指定されたファイルが見つかりません");
             }
 
             $handle = fopen($filePath, 'r');
@@ -108,7 +108,7 @@ class ElectionDataService
 
             return [
                 'status' => 'error',
-                'message' => $e->getMessage(),
+                'message' => 'CSVインポートに失敗しました',
                 'imported' => $imported,
             ];
         }
@@ -126,7 +126,7 @@ class ElectionDataService
             DB::beginTransaction();
 
             if (!file_exists($filePath)) {
-                throw new \Exception("ファイルが見つかりません: {$filePath}");
+                throw new \Exception("指定されたファイルが見つかりません");
             }
 
             $handle = fopen($filePath, 'r');
@@ -178,7 +178,7 @@ class ElectionDataService
 
             return [
                 'status' => 'error',
-                'message' => $e->getMessage(),
+                'message' => '世論調査データインポートに失敗しました',
                 'imported' => $imported,
             ];
         }


### PR DESCRIPTION
## Summary

- Replace `$e->getMessage()` with generic messages in CSV import error JSON responses
- Fix file-not-found exceptions that leaked absolute server paths (`"ファイルが見つかりません: {$filePath}"`)
- `Log::error()` already present — real errors continue to be logged server-side

## Security Issue

Both `importElectionDataFromCsv()` and `importPollDataFromCsv()` returned `$e->getMessage()` directly in the API JSON response. This exposed:
- **Absolute server file paths** via the "ファイルが見つかりません: {$filePath}" exception message
- **Internal DB/PHP error details** on unexpected database errors (SQL syntax, schema names, etc.)

## Changes

| File | Change |
|------|--------|
| `app/Services/ElectionDataService.php` | Replace `$e->getMessage()` with `'CSVインポートに失敗しました'` / `'世論調査データインポートに失敗しました'`; remove file path from "file not found" exception messages |

## Test plan

- [ ] Upload a valid CSV — verify success response is unchanged
- [ ] Upload a non-existent path — verify response shows generic error, not a file path
- [ ] Trigger a DB error during import — verify response shows generic error, and `Log::error` captures the real message

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_