### PR TITLE
security: guard computed and GDPR fields in Customer model from mass assignment

### DIFF
--- a/laravel_project/app/Models/Customer.php
+++ b/laravel_project/app/Models/Customer.php
@@ -17,12 +17,15 @@ class Customer extends Model
         'email',
         'phone',
         'address',
-        'last_stay_date',
-        'total_stays',
-        'total_spent',
         'privacy_consent',
         'privacy_consent_date',
         'marketing_consent',
+    ];
+
+    protected $guarded = [
+        'total_stays',
+        'total_spent',
+        'last_stay_date',
         'deletion_requested',
         'deletion_requested_at',
     ];


### PR DESCRIPTION
## Summary

- Move `total_stays`, `total_spent`, `last_stay_date` (aggregate/audit fields) to `$guarded`
- Move `deletion_requested`, `deletion_requested_at` (GDPR fields) to `$guarded`
- These fields are managed exclusively via dedicated model methods — not via user input

## Security Issue

The `Customer` model had aggregate statistics and GDPR deletion-request flags in `$fillable`, making them vulnerable to mass assignment:

| Guarded field | Risk |
|---------------|------|
| `total_stays` | Attacker could spoof customer loyalty level |
| `total_spent` | Attacker could manipulate spending history and member rank |
| `last_stay_date` | Attacker could falsify recency of stays |
| `deletion_requested` | Attacker could clear a pending GDPR deletion request |
| `deletion_requested_at` | Attacker could manipulate GDPR audit timestamps |

## Why `updateStayHistory()` and `requestDeletion()` still work

Both methods use direct property assignment + `save()`, not `$this->update([...])`, so they are unaffected by `$guarded`.

## Changes

**`app/Models/Customer.php`** — removed 5 fields from `$fillable`, added them to `$guarded`:

```php
protected $fillable = ['name', 'email', 'phone', 'address', 'privacy_consent', 'privacy_consent_date', 'marketing_consent'];
protected $guarded  = ['total_stays', 'total_spent', 'last_stay_date', 'deletion_requested', 'deletion_requested_at'];
```

## Test plan

- [ ] Create customer via admin form — only name/email/phone/address/consent set
- [ ] Complete a travel booking — `firstOrCreate` still sets privacy consent correctly
- [ ] Manually call `updateStayHistory(1000)` — `total_stays`/`total_spent` update correctly
- [ ] Call `requestDeletion()` — `deletion_requested` and `deletion_requested_at` set correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_