### PR TITLE
fix: stop leaking exception message in election predict API response

### DIFF
--- a/laravel_project/app/Http/Controllers/ElectionController.php
+++ b/laravel_project/app/Http/Controllers/ElectionController.php
@@ -12,6 +12,7 @@ use App\Services\ElectionDataService;
 use App\Services\ElectionAnalysisService;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Log;
 use Carbon\Carbon;
 
 class ElectionController extends Controller
@@ -145,9 +146,14 @@ class ElectionController extends Controller
                 'data' => $result,
             ]);
         } catch (\Exception $e) {
+            Log::error('Election seat prediction failed', [
+                'election_id' => $election->id,
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
             return response()->json([
                 'status' => 'error',
-                'message' => '予測中にエラーが発生しました: ' . $e->getMessage(),
+                'message' => '議席予測に失敗しました',
             ], 500);
         }
     }


### PR DESCRIPTION
## Summary

- `ElectionController::predict()` was concatenating `$e->getMessage()` directly into the 500 JSON response, exposing internal SQL schema, class names, and file paths to API consumers
- Added `Log::error()` with full exception details (message + trace) for server-side diagnostics
- Replaced the leaked message with a generic Japanese error string returned to clients

## Security Impact

**Before:**
```json
{"status":"error","message":"予測中にエラーが発生しました: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'predicted_seats' in 'field list' (SQL: select `predicted_seats` from `seat_predictions` ...)"}
```

**After:**
```json
{"status":"error","message":"議席予測に失敗しました"}
```

## Test plan

- [ ] Trigger a prediction failure (e.g., bad election ID or DB error in test env) and confirm the response body contains only the generic message
- [ ] Confirm the full exception details appear in `storage/logs/laravel.log`
- [ ] Confirm successful predictions still return `{"status":"success","data":{...}}`

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_