### PR TITLE
fix: guard aggregate review scores against mass assignment in Accommodation

### DIFF
--- a/laravel_project/app/Models/Accommodation.php
+++ b/laravel_project/app/Models/Accommodation.php
@@ -30,13 +30,6 @@ class Accommodation extends Model
         'nearest_station_id',
         'station_distance_minutes',
         'star_rating',
-        'review_score',
-        'review_count',
-        'cleanliness_score',
-        'service_score',
-        'location_score',
-        'facility_score',
-        'value_score',
         'highlight_features',
         'parking_info',
         'access_info',
@@ -46,6 +39,16 @@ class Accommodation extends Model
         'is_new',
         'display_priority',
         'cancellation_policy_id',
+    ];
+
+    protected $guarded = [
+        'review_score',
+        'review_count',
+        'cleanliness_score',
+        'service_score',
+        'location_score',
+        'facility_score',
+        'value_score',
     ];
 
     protected $casts = [


### PR DESCRIPTION
## Summary

- `review_score`, `review_count`, `cleanliness_score`, `service_score`, `location_score`, `facility_score`, `value_score` were all in `$fillable` on the `Accommodation` model
- These are computed aggregates derived from `Review` records — they should never be writable via mass assignment
- Moved them out of `$fillable` and into `$guarded` to prevent an attacker from inflating or manipulating ratings through any endpoint that creates/updates accommodations with user-supplied input

## Security Impact

An attacker who can reach any endpoint calling `Accommodation::create()` or `Accommodation::update()` with arbitrary input could pass `review_score=5.0&review_count=9999` to manipulate search rankings and displayed ratings without writing a single real review.

## Test plan

- [ ] Confirm legitimate create/update flows (admin accommodation management) still work
- [ ] Confirm that passing `review_score` in a request body is silently ignored by Eloquent
- [ ] Confirm `Review`-triggered aggregate recalculation (direct property assignment + `save()`) still updates the scores correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_