### PR TITLE
fix: replace raw exception messages with generic errors in PaymentController

### DIFF
--- a/laravel_project/app/Http/Controllers/PaymentController.php
+++ b/laravel_project/app/Http/Controllers/PaymentController.php
@@ -6,6 +6,7 @@ use App\Models\Payment;
 use App\Models\Reservation;
 use App\Services\PaymentService;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Inertia\Inertia;
 
 class PaymentController extends Controller
@@ -70,7 +71,8 @@ class PaymentController extends Controller
             return redirect()->route('payments.show', $payment)
                 ->with('success', '決済を作成しました。');
         } catch (\Exception $e) {
-            return back()->withInput()->withErrors(['error' => $e->getMessage()]);
+            Log::error('Payment creation failed', ['error' => $e->getMessage(), 'trace' => $e->getTraceAsString()]);
+            return back()->withInput()->withErrors(['error' => '決済の作成に失敗しました']);
         }
     }
 
@@ -96,7 +98,8 @@ class PaymentController extends Controller
             return redirect()->route('payments.show', $payment)
                 ->with('success', '決済処理が完了しました。');
         } catch (\Exception $e) {
-            return back()->withErrors(['error' => $e->getMessage()]);
+            Log::error('Payment processing failed', ['payment_id' => $payment->id, 'error' => $e->getMessage(), 'trace' => $e->getTraceAsString()]);
+            return back()->withErrors(['error' => '決済処理に失敗しました']);
         }
     }
 
@@ -120,7 +123,8 @@ class PaymentController extends Controller
             return redirect()->route('payments.show', $payment)
                 ->with('success', '返金処理が完了しました。');
         } catch (\Exception $e) {
-            return back()->withErrors(['error' => $e->getMessage()]);
+            Log::error('Payment refund failed', ['payment_id' => $payment->id, 'error' => $e->getMessage(), 'trace' => $e->getTraceAsString()]);
+            return back()->withErrors(['error' => '返金処理に失敗しました']);
         }
     }
 
@@ -135,7 +139,8 @@ class PaymentController extends Controller
             return redirect()->route('payments.show', $payment)
                 ->with('success', '決済をキャンセルしました。');
         } catch (\Exception $e) {
-            return back()->withErrors(['error' => $e->getMessage()]);
+            Log::error('Payment cancellation failed', ['payment_id' => $payment->id, 'error' => $e->getMessage(), 'trace' => $e->getTraceAsString()]);
+            return back()->withErrors(['error' => '決済キャンセルに失敗しました']);
         }
     }
 


### PR DESCRIPTION
## Summary

All four catch blocks in `PaymentController` (`store`, `process`, `refund`, `cancel`) were calling `back()->withErrors(['error' => $e->getMessage()])`, surfacing raw exception messages directly to the browser. This exposes internal details such as:

- SQL errors (table/column names, query fragments)
- Payment gateway error responses (keys, endpoint URLs)
- PHP class names and file paths from the stack trace

Each catch block now:
1. Logs the full exception (`message` + `trace`) via `Log::error()` for server-side diagnostics
2. Returns a fixed, generic Japanese message to the client

## Test plan

- [ ] Trigger each failure path (bad reservation ID, gateway timeout, already-refunded payment) and confirm the browser only sees the generic message
- [ ] Confirm full error details appear in `storage/logs/laravel.log`
- [ ] Confirm happy paths (successful store, process, refund, cancel) still redirect with the success flash message

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_