### PR TITLE
fix: guard admin/moderation fields against mass assignment in Review model

### DIFF
--- a/laravel_project/app/Http/Controllers/ReviewController.php
+++ b/laravel_project/app/Http/Controllers/ReviewController.php
@@ -116,8 +116,11 @@ class ReviewController extends Controller
             'amenities_rating' => $validated['amenities_rating'] ?? null,
             'title' => $validated['title'] ?? null,
             'comment' => $validated['comment'] ?? null,
-            'is_verified' => true, // 実際の予約からのレビューなので自動的に認証済み
         ]);
+
+        // Verified flag is set by the application, not via mass assignment
+        $review->is_verified = true;
+        $review->save();
 
         return redirect()->route('reviews.show', $review)
             ->with('success', 'レビューを投稿しました。ありがとうございます！');

--- a/laravel_project/app/Models/Review.php
+++ b/laravel_project/app/Models/Review.php
@@ -105,7 +105,8 @@ class Review extends Model
      */
     public function publish(): void
     {
-        $this->update(['is_published' => true]);
+        $this->is_published = true;
+        $this->save();
     }
 
     /**
@@ -113,7 +114,8 @@ class Review extends Model
      */
     public function unpublish(): void
     {
-        $this->update(['is_published' => false]);
+        $this->is_published = false;
+        $this->save();
     }
 
     /**
@@ -121,7 +123,8 @@ class Review extends Model
      */
     public function verify(): void
     {
-        $this->update(['is_verified' => true]);
+        $this->is_verified = true;
+        $this->save();
     }
 
     /**
@@ -129,10 +132,9 @@ class Review extends Model
      */
     public function addAdminResponse(string $response): void
     {
-        $this->update([
-            'admin_response' => $response,
-            'admin_responded_at' => now(),
-        ]);
+        $this->admin_response = $response;
+        $this->admin_responded_at = now();
+        $this->save();
     }
 
     /**

--- a/laravel_project/app/Models/Review.php
+++ b/laravel_project/app/Models/Review.php
@@ -24,6 +24,9 @@ class Review extends Model
         'title',
         'comment',
         'photos',
+    ];
+
+    protected $guarded = [
         'is_verified',
         'is_published',
         'admin_response',


### PR DESCRIPTION
## Summary

- `is_published`, `admin_response`, `admin_responded_at`, `helpful_count`, and `is_verified` were all in `$fillable` on the `Review` model
- These are admin-controlled or aggregate fields — not fields a reviewer should be able to set via mass assignment
- Moved all five to `$guarded`
- The one legitimate internal call that set `is_verified => true` at creation (`ReviewController::store`) now uses direct property assignment after `create()` instead of relying on mass assignment

## Security Impact

With these fields in `$fillable`, a crafted request reaching any endpoint that calls `Review::create($userInput)` or `$review->update($userInput)` could:
- Bypass moderation by setting `is_published = true` directly
- Inject admin responses without going through the admin endpoint
- Artificially inflate `helpful_count`

## Test plan

- [ ] Submit a new review and confirm `is_verified` is set to `true` and the review saves correctly
- [ ] Confirm that passing `is_published=1` or `helpful_count=999` in a review form/API request has no effect
- [ ] Confirm the admin response flow (via `ReviewController::addAdminResponse`) still works
- [ ] Confirm `helpful_count` increments correctly via the helpful-vote endpoint

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_