### PR TITLE
fix: guard system-set Payment fields against mass assignment

### DIFF
--- a/laravel_project/app/Models/Payment.php
+++ b/laravel_project/app/Models/Payment.php
@@ -14,16 +14,19 @@ class Payment extends Model
         'reservation_id',
         'amount',
         'payment_method',
-        'status',
-        'transaction_id',
         'payment_gateway',
         'payment_details',
+        'notes',
+    ];
+
+    protected $guarded = [
+        'status',
+        'transaction_id',
         'paid_at',
         'refunded_at',
         'refund_amount',
         'refund_reason',
         'failure_reason',
-        'notes',
     ];
 
     protected $casts = [
@@ -47,11 +50,10 @@ class Payment extends Model
      */
     public function markAsPaid(string $transactionId = null): void
     {
-        $this->update([
-            'status' => 'completed',
-            'paid_at' => now(),
-            'transaction_id' => $transactionId ?? $this->transaction_id,
-        ]);
+        $this->status = 'completed';
+        $this->paid_at = now();
+        $this->transaction_id = $transactionId ?? $this->transaction_id;
+        $this->save();
     }
 
     /**
@@ -59,10 +61,9 @@ class Payment extends Model
      */
     public function markAsFailed(string $reason): void
     {
-        $this->update([
-            'status' => 'failed',
-            'failure_reason' => $reason,
-        ]);
+        $this->status = 'failed';
+        $this->failure_reason = $reason;
+        $this->save();
     }
 
     /**
@@ -70,14 +71,11 @@ class Payment extends Model
      */
     public function refund(float $amount = null, string $reason = null): void
     {
-        $refundAmount = $amount ?? $this->amount;
-
-        $this->update([
-            'status' => 'refunded',
-            'refunded_at' => now(),
-            'refund_amount' => $refundAmount,
-            'refund_reason' => $reason,
-        ]);
+        $this->status = 'refunded';
+        $this->refunded_at = now();
+        $this->refund_amount = $amount ?? $this->amount;
+        $this->refund_reason = $reason;
+        $this->save();
     }
 
     /**

--- a/laravel_project/app/Services/PaymentService.php
+++ b/laravel_project/app/Services/PaymentService.php
@@ -35,7 +35,8 @@ class PaymentService
     {
         return DB::transaction(function () use ($payment, $paymentData) {
             // ステータスを処理中に変更
-            $payment->update(['status' => 'processing']);
+            $payment->status = 'processing';
+            $payment->save();
 
             try {
                 // 実際の決済ゲートウェイとの連携処理
@@ -166,7 +167,8 @@ class PaymentService
             throw new Exception('この決済はキャンセルできません。');
         }
 
-        $payment->update(['status' => 'cancelled']);
+        $payment->status = 'cancelled';
+        $payment->save();
 
         return $payment;
     }


### PR DESCRIPTION
## Summary

`status`, `transaction_id`, `paid_at`, `refunded_at`, `refund_amount`, `refund_reason`, and `failure_reason` were all in `$fillable` on the `Payment` model. These are set exclusively by internal payment-gateway logic and must not be writable via mass assignment.

### Changes

**`app/Models/Payment.php`**
- Removed the seven system-set fields from `$fillable`
- Added them to `$guarded`
- Updated `markAsPaid()`, `markAsFailed()`, and `refund()` to use direct property assignment + `save()` (they previously used `update()`, which would silently no-op once the fields became guarded)

**`app/Services/PaymentService.php`**
- `processPayment()`: changed `$payment->update(['status' => 'processing'])` → direct assignment + `save()`
- `cancelPayment()`: changed `$payment->update(['status' => 'cancelled'])` → direct assignment + `save()`

## Security Impact

With `status` in `$fillable`, a crafted request that reaches `Payment::create()` or `payment->update()` with unchecked data could set `status=completed` or `status=refunded` without actually going through the payment gateway.

## Test plan

- [ ] Create a payment and confirm it starts in the default `pending` status
- [ ] Process a payment and confirm `status` transitions to `processing` → `completed`, and `paid_at`/`transaction_id` are set correctly
- [ ] Trigger a payment failure and confirm `status` → `failed` and `failure_reason` is recorded
- [ ] Refund a payment and confirm `status` → `refunded`, `refunded_at` and `refund_amount` are set
- [ ] Cancel a payment and confirm `status` → `cancelled`
- [ ] Confirm passing `status=completed` in a store request has no effect

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_