### PR TITLE
fix: use direct property assignment for Customer total_points in PointTransaction

### DIFF
--- a/laravel_project/app/Models/PointTransaction.php
+++ b/laravel_project/app/Models/PointTransaction.php
@@ -60,7 +60,8 @@ class PointTransaction extends Model
         return DB::transaction(function () use ($customerId, $points, $description, $reservationId, $expireDate) {
             $customer = Customer::lockForUpdate()->findOrFail($customerId);
             $newBalance = $customer->total_points + $points;
-            $customer->update(['total_points' => $newBalance]);
+            $customer->total_points = $newBalance;
+            $customer->save();
 
             return self::create([
                 'customer_id' => $customerId,
@@ -91,7 +92,8 @@ class PointTransaction extends Model
             }
 
             $newBalance = $customer->total_points - $points;
-            $customer->update(['total_points' => $newBalance]);
+            $customer->total_points = $newBalance;
+            $customer->save();
 
             return self::create([
                 'customer_id' => $customerId,


### PR DESCRIPTION
## Summary

`PointTransaction::earn()` and `PointTransaction::use()` both called:
```php
$customer->update(['total_points' => $newBalance]);
```

However, `total_points` is **not** in `Customer::$fillable`. Laravel's mass assignment protection silently drops unwhitelisted fields in `update()`, so every point transaction completed without error but the customer's balance was **never actually persisted** — it remained at zero indefinitely.

## Fix

Replaced `update([...])` with direct property assignment + `save()`:
```php
$customer->total_points = $newBalance;
$customer->save();
```

Direct property assignment bypasses `$fillable`/`$guarded` and is the correct pattern for trusted internal model operations where mass assignment protection should not apply.

## Test plan

- [ ] Call `PointTransaction::earn($customerId, 100, 'Test earn')` and confirm `Customer::find($customerId)->total_points` increments by 100
- [ ] Call `PointTransaction::use($customerId, 50, 'Test use')` and confirm balance decrements by 50
- [ ] Confirm the transaction record is also created with the correct `balance_after` value
- [ ] Confirm `use()` throws when points are insufficient

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_