### PR TITLE
fix: add input validation to EventController::calendar and TravelController::areas

### DIFF
--- a/laravel_project/app/Http/Controllers/EventController.php
+++ b/laravel_project/app/Http/Controllers/EventController.php
@@ -179,8 +179,13 @@ class EventController extends Controller
      */
     public function calendar(Request $request)
     {
-        $region = $request->get('region', '東京');
-        $month = $request->get('month', date('Y-m'));
+        $validated = $request->validate([
+            'region' => 'nullable|string|max:100',
+            'month'  => 'nullable|date_format:Y-m',
+        ]);
+
+        $region = $validated['region'] ?? '東京';
+        $month  = $validated['month'] ?? date('Y-m');
 
         $startDate = $month . '-01';
         $endDate = date('Y-m-t', strtotime($startDate));

--- a/laravel_project/app/Http/Controllers/TravelController.php
+++ b/laravel_project/app/Http/Controllers/TravelController.php
@@ -348,8 +348,13 @@ class TravelController extends Controller
      */
     public function areas(Request $request): JsonResponse
     {
-        $parentId = $request->input('parent_id');
-        $level = $request->input('level');
+        $validated = $request->validate([
+            'parent_id' => 'nullable|integer|min:1',
+            'level'     => 'nullable|integer|min:1|max:5',
+        ]);
+
+        $parentId = $validated['parent_id'] ?? null;
+        $level    = $validated['level'] ?? null;
 
         $query = Area::query();
 


### PR DESCRIPTION
## Summary

Two public API/web endpoints were reading request parameters without validation:

### `EventController::calendar()`
- `$month` was read directly from the request and concatenated into a date string (`$month . '-01'`), then passed to `strtotime()`. An invalid `month` value (e.g. `"../../etc"`, `"9999-99"`) caused `strtotime()` to return `false`, producing an unexpected `$endDate` and potentially passing garbage to the event search service.
- `$region` had no length bound.
- Fix: validates `month` as `date_format:Y-m` and `region` as `string|max:100`

### `TravelController::areas()`
- `$parentId` and `$level` were read as raw strings and passed directly to Eloquent `where()` without type checking. While parameterized queries prevent SQL injection, non-integer values produce unexpected query behavior.
- Fix: validates both as `nullable|integer` with sensible bounds

## Test plan

- [ ] `GET /events/calendar?month=invalid` returns a 422 validation error instead of serving a page with a corrupted date range
- [ ] `GET /events/calendar?month=2025-06` continues to work
- [ ] `GET /travel/areas?parent_id=abc` returns 422
- [ ] `GET /travel/areas?parent_id=1` returns the expected child areas

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_