### PR TITLE
fix: replace innerHTML template literals with safe DOM API in JS views

### DIFF
--- a/laravel_project/resources/views/elections/show.blade.php
+++ b/laravel_project/resources/views/elections/show.blade.php
@@ -346,7 +346,10 @@ document.getElementById('addResultModal')?.addEventListener('show.bs.modal', fun
         const select = this.querySelector('select[name="district_id"]');
         select.innerHTML = '<option value="">選択してください</option>';
         data.data.forEach(district => {
-            select.innerHTML += `<option value="${district.id}">${district.name}</option>`;
+            const opt = document.createElement('option');
+            opt.value = district.id;
+            opt.textContent = district.name;
+            select.appendChild(opt);
         });
     });
 
@@ -357,7 +360,10 @@ document.getElementById('addResultModal')?.addEventListener('show.bs.modal', fun
         const select = this.querySelector('select[name="party_id"]');
         select.innerHTML = '<option value="">選択してください</option>';
         data.data.forEach(party => {
-            select.innerHTML += `<option value="${party.id}">${party.name}</option>`;
+            const opt = document.createElement('option');
+            opt.value = party.id;
+            opt.textContent = party.name;
+            select.appendChild(opt);
         });
     });
 });

--- a/laravel_project/resources/views/travel/index.blade.php
+++ b/laravel_project/resources/views/travel/index.blade.php
@@ -267,12 +267,21 @@ keywordInput?.addEventListener('input', function() {
                     return;
                 }
 
-                suggestDropdown.innerHTML = data.data.map(item => `
-                    <a class="dropdown-item" href="#" data-type="${item.type}" data-id="${item.id}" data-name="${item.name}">
-                        <small class="text-muted">${item.type === 'area' ? 'エリア' : '施設'}</small>
-                        ${item.label}
-                    </a>
-                `).join('');
+                suggestDropdown.innerHTML = '';
+                data.data.forEach(item => {
+                    const a = document.createElement('a');
+                    a.className = 'dropdown-item';
+                    a.href = '#';
+                    a.dataset.type = item.type;
+                    a.dataset.id = item.id;
+                    a.dataset.name = item.name;
+                    const small = document.createElement('small');
+                    small.className = 'text-muted';
+                    small.textContent = item.type === 'area' ? 'エリア' : '施設';
+                    a.appendChild(small);
+                    a.appendChild(document.createTextNode(' ' + item.label));
+                    suggestDropdown.appendChild(a);
+                });
                 suggestDropdown.style.display = 'block';
             });
     }, 300);


### PR DESCRIPTION
## Summary

Two views were building DOM elements via `innerHTML` with template literals populated from API response data. If any field returned by the API contained HTML characters (e.g. a district/party name stored with `<script>alert(1)</script>`), it would execute as code in the browser.

### `elections/show.blade.php`

District and party option elements were rendered using:
```js
select.innerHTML += `<option value="${district.id}">${district.name}</option>`;
```

**After:** `createElement('option')` + `opt.value = district.id` + `opt.textContent = district.name`

### `travel/index.blade.php`

Autocomplete suggestion links were rendered using a `map()` template literal over the full API response:
```js
suggestDropdown.innerHTML = data.data.map(item => `
    <a ... data-id="${item.id}" data-name="${item.name}">
        <small>${item.type === 'area' ? '...' : '...'}</small>
        ${item.label}
    </a>
`).join('');
```

**After:** `createElement('a')` + `dataset.*` + `textContent` + `createTextNode` for label

## Test plan

- [ ] Autocomplete still works in the travel search page
- [ ] Election result modal shows the correct district and party lists
- [ ] A district/party name containing `<b>bold</b>` renders as literal text, not HTML

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_