### PR TITLE
fix: prevent file path and exception message disclosure in ElectionDataService

### DIFF
--- a/laravel_project/app/Services/ElectionDataService.php
+++ b/laravel_project/app/Services/ElectionDataService.php
@@ -71,7 +71,7 @@ class ElectionDataService
             DB::beginTransaction();
 
             if (!file_exists($filePath)) {
-                throw new \Exception("ファイルが見つかりません: {$filePath}");
+                throw new \Exception("指定されたファイルが見つかりません");
             }
 
             $handle = fopen($filePath, 'r');
@@ -108,7 +108,7 @@ class ElectionDataService
 
             return [
                 'status' => 'error',
-                'message' => $e->getMessage(),
+                'message' => 'CSVインポートに失敗しました',
                 'imported' => $imported,
             ];
         }
@@ -126,7 +126,7 @@ class ElectionDataService
             DB::beginTransaction();
 
             if (!file_exists($filePath)) {
-                throw new \Exception("ファイルが見つかりません: {$filePath}");
+                throw new \Exception("指定されたファイルが見つかりません");
             }
 
             $handle = fopen($filePath, 'r');
@@ -178,7 +178,7 @@ class ElectionDataService
 
             return [
                 'status' => 'error',
-                'message' => $e->getMessage(),
+                'message' => '世論調査データインポートに失敗しました',
                 'imported' => $imported,
             ];
         }


### PR DESCRIPTION
## Summary

- Remove server-side file path from exception messages in `importElectionDataFromCsv()` and `importPollDataFromCsv()` — previously the path was included in the thrown exception string which could surface to callers
- Replace raw `$e->getMessage()` in catch block API responses with generic strings so PHP/SQL internals are never returned to API clients
- Full error details are still logged via `Log::error()` for debugging

## Security impact

**Information disclosure** — returning exception messages directly to API clients can expose internal server paths, SQL query details, and PHP stack context to attackers.

| Location | Before | After |
|---|---|---|
| `importElectionDataFromCsv` exception | `"ファイルが見つかりません: {$filePath}"` | `"指定されたファイルが見つかりません"` |
| `importElectionDataFromCsv` catch | `'message' => $e->getMessage()` | `'message' => 'CSVインポートに失敗しました'` |
| `importPollDataFromCsv` exception | `"ファイルが見つかりません: {$filePath}"` | `"指定されたファイルが見つかりません"` |
| `importPollDataFromCsv` catch | `'message' => $e->getMessage()` | `'message' => '世論調査データインポートに失敗しました'` |

## Test plan

- [ ] Upload a valid CSV file — import succeeds normally
- [ ] Upload a file to a non-existent path — response returns generic error message, not the file system path
- [ ] Trigger an import error — response returns generic message; full details appear in Laravel logs only

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_