### PR TITLE
fix: guard system-managed fields in Reservation model and remove status from user input

### DIFF
--- a/laravel_project/app/Http/Controllers/ReservationController.php
+++ b/laravel_project/app/Http/Controllers/ReservationController.php
@@ -29,12 +29,13 @@ class ReservationController extends Controller
             'room_id' => 'required|exists:rooms,id',
             'check_in_date' => 'required|date|after_or_equal:today',
             'check_out_date' => 'required|date|after:check_in_date',
-            'status' => 'required|in:pending,confirmed,cancelled,completed',
             'total_amount' => 'required|numeric|min:0',
             'notes' => 'nullable|string',
         ]);
 
-        Reservation::create($validated);
+        $reservation = Reservation::create($validated);
+        $reservation->status = Reservation::STATUS_PROVISIONAL;
+        $reservation->save();
 
         return redirect()->route('reservations.index')
             ->with('success', '予約を登録しました。');
@@ -60,7 +61,6 @@ class ReservationController extends Controller
             'room_id' => 'required|exists:rooms,id',
             'check_in_date' => 'required|date',
             'check_out_date' => 'required|date|after:check_in_date',
-            'status' => 'required|in:pending,confirmed,cancelled,completed',
             'total_amount' => 'required|numeric|min:0',
             'notes' => 'nullable|string',
         ]);

--- a/laravel_project/app/Models/Reservation.php
+++ b/laravel_project/app/Models/Reservation.php
@@ -35,18 +35,21 @@ class Reservation extends Model
         'number_of_guests',
         'check_in_date',
         'check_out_date',
-        'status',
-        'payment_status',
-        'actual_check_in_time',
-        'actual_check_out_time',
         'total_amount',
         'applied_discounts',
         'price_breakdown',
-        'cancelled_at',
         'cancellation_reason',
         'notes',
         'created_by_user_id',
         'updated_by_user_id',
+    ];
+
+    protected $guarded = [
+        'status',
+        'payment_status',
+        'actual_check_in_time',
+        'actual_check_out_time',
+        'cancelled_at',
     ];
 
     protected $casts = [

--- a/laravel_project/app/Services/ReservationService.php
+++ b/laravel_project/app/Services/ReservationService.php
@@ -203,7 +203,12 @@ class ReservationService
                 $data['price_breakdown'] = $pricing['breakdown'];
             }
 
-            $reservation->update($data);
+            $allowedFields = [
+                'number_of_guests', 'check_in_date', 'check_out_date',
+                'total_amount', 'applied_discounts', 'price_breakdown',
+                'cancellation_reason', 'notes', 'updated_by_user_id',
+            ];
+            $reservation->update(array_intersect_key($data, array_flip($allowedFields)));
 
             if (isset($data['user_id'])) {
                 $reservation->updated_by_user_id = $data['user_id'];


### PR DESCRIPTION
## Summary

- Move `status`, `payment_status`, `actual_check_in_time`, `actual_check_out_time`, and `cancelled_at` to `$guarded` in the Reservation model so they cannot be set via mass assignment
- Remove `status` from `ReservationController::store()` validation — new reservations always start as `STATUS_PROVISIONAL` via direct assignment
- Remove `status` from `ReservationController::update()` validation — status changes must go through `changeStatus()` / `canTransitionTo()` state machine
- Whitelist allowed fields in `ReservationService::updateReservation()` to prevent raw caller data from bypassing the guard

## Security impact

**State machine bypass** — `status` was accepted directly from user-controlled HTTP input and passed to `Reservation::create()` / `$reservation->update()`, allowing an HTTP client to create a reservation with `status=confirmed` or `status=checked_out` without going through the `canTransitionTo()` guard.

**System field tampering** — `payment_status`, `actual_check_in_time`, `actual_check_out_time`, and `cancelled_at` are all set by service/controller code internally; having them in `$fillable` would allow any mass-assignment call to overwrite them.

## Test plan

- [ ] Create a new reservation — status is `provisional` regardless of any submitted `status` field
- [ ] Attempt to POST `status=confirmed` on create — must be ignored
- [ ] Update a reservation's dates and notes — succeeds
- [ ] Attempt to update `status` via the edit form — field not accepted
- [ ] Use `Reservation::changeStatus()` — correctly transitions through state machine

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_