### PR TITLE
fix: guard computed stats and GDPR flags in Customer model against mass assignment

### DIFF
--- a/laravel_project/app/Models/Customer.php
+++ b/laravel_project/app/Models/Customer.php
@@ -17,12 +17,15 @@ class Customer extends Model
         'email',
         'phone',
         'address',
-        'last_stay_date',
-        'total_stays',
-        'total_spent',
         'privacy_consent',
         'privacy_consent_date',
         'marketing_consent',
+    ];
+
+    protected $guarded = [
+        'total_stays',
+        'total_spent',
+        'last_stay_date',
         'deletion_requested',
         'deletion_requested_at',
     ];


### PR DESCRIPTION
## Summary

- Move `total_stays`, `total_spent`, `last_stay_date`, `deletion_requested`, and `deletion_requested_at` from `$fillable` to `$guarded` in the Customer model
- These fields are managed exclusively by `updateStayHistory()` and `requestDeletion()` model methods and must never be reachable via mass assignment

## Security impact

**Statistic falsification** — `total_stays` and `total_spent` are fillable, meaning any code path that mass-assigns from request data could artificially inflate or zero-out a customer's loyalty statistics, which in turn affect membership tier calculations.

**GDPR erasure suppression** — `deletion_requested` and `deletion_requested_at` being fillable means an attacker who can reach a mass-assignment code path could flip `deletion_requested = false` and `deletion_requested_at = null` to silently cancel a submitted GDPR erasure request.

All four guarded fields are already set via direct property assignment in the model's own methods (`$this->total_stays += 1`, `$this->deletion_requested = true`, etc.) so guarding them does not break any existing functionality.

## Test plan

- [ ] Create a customer via the form — `total_stays`, `total_spent`, `last_stay_date`, `deletion_requested` are all zero/null
- [ ] POST `total_stays=999` on customer create/update — field is silently ignored
- [ ] Call `customer->updateStayHistory(amount)` — stats update correctly via direct assignment
- [ ] Call `customer->requestDeletion()` — `deletion_requested` becomes true correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_