### PR TITLE
fix: require admin role for review admin-response endpoint

### DIFF
--- a/laravel_project/app/Http/Controllers/ReviewController.php
+++ b/laravel_project/app/Http/Controllers/ReviewController.php
@@ -205,6 +205,8 @@ class ReviewController extends Controller
      */
     public function addAdminResponse(Review $review, Request $request)
     {
+        abort_unless(auth()->user()?->is_admin, 403, '管理者権限が必要です。');
+
         $validated = $request->validate([
             'admin_response' => 'required|string|max:1000',
         ]);


### PR DESCRIPTION
## Summary

- Add `abort_unless(auth()->user()?->is_admin, 403)` to `ReviewController::addAdminResponse()` to restrict the endpoint to administrators only

## Security impact

**Privilege escalation** — `POST /reviews/{review}/admin-response` was gated only by the generic `auth` middleware. Any authenticated user (customer, staff, etc.) could POST to this route and publish an "admin response" on any review, potentially impersonating hotel administration with misleading content visible to all future guests.

## Test plan

- [ ] As a non-admin authenticated user: POST to `/reviews/{id}/admin-response` — receives 403
- [ ] As an admin user (`is_admin = true`): POST succeeds, response is saved
- [ ] Unauthenticated request: redirected to login (existing `auth` middleware)

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_