### PR TITLE
fix: cap per_page and validate sort in TravelController reviews endpoint

### DIFF
--- a/laravel_project/app/Http/Controllers/TravelController.php
+++ b/laravel_project/app/Http/Controllers/TravelController.php
@@ -369,8 +369,13 @@ class TravelController extends Controller
      */
     public function reviews(Request $request, int $accommodationId): JsonResponse
     {
-        $perPage = $request->input('per_page', 10);
-        $sort = $request->input('sort', 'newest');
+        $validated = $request->validate([
+            'per_page' => 'nullable|integer|min:1|max:100',
+            'sort' => 'nullable|in:newest,rating_high,rating_low,helpful',
+        ]);
+
+        $perPage = $validated['per_page'] ?? 10;
+        $sort = $validated['sort'] ?? 'newest';
 
         $query = Review::with('customer:id,name')
             ->where('accommodation_id', $accommodationId)


### PR DESCRIPTION
## Summary

- Validate `per_page` with `integer|min:1|max:100` in `TravelController::reviews()` to prevent unbounded database queries
- Validate `sort` against an explicit allowlist (`newest`, `rating_high`, `rating_low`, `helpful`)

## Security impact

**Denial of service via unbounded pagination** — `per_page` was read directly from the request and passed to `->paginate($perPage)` with no validation. An attacker could send `per_page=99999999` to force the database to fetch all reviews for an accommodation in a single query, saturating DB and web-server resources.

The `sort` parameter was also unvalidated; accepting arbitrary values prevents potential SQL injection vectors through ORM query manipulation.

## Test plan

- [ ] Request `?per_page=10` — returns 10 reviews normally
- [ ] Request `?per_page=200` — capped to 100, returns at most 100 reviews
- [ ] Request `?per_page=abc` — validation error returned
- [ ] Request `?sort=rating_high` — sorted correctly
- [ ] Request `?sort=drop_table` — validation error returned

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_