### PR TITLE
fix: use validated data in processPayment and prevent exception disclosure in PaymentController

### DIFF
--- a/laravel_project/app/Http/Controllers/PaymentController.php
+++ b/laravel_project/app/Http/Controllers/PaymentController.php
@@ -6,6 +6,7 @@ use App\Models\Payment;
 use App\Models\Reservation;
 use App\Services\PaymentService;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Inertia\Inertia;
 
 class PaymentController extends Controller
@@ -64,13 +65,14 @@ class PaymentController extends Controller
 
             // 決済処理を実行
             if ($request->has('process_now') && $request->input('process_now')) {
-                $this->paymentService->processPayment($payment, $request->all());
+                $this->paymentService->processPayment($payment, $validated);
             }
 
             return redirect()->route('payments.show', $payment)
                 ->with('success', '決済を作成しました。');
         } catch (\Exception $e) {
-            return back()->withInput()->withErrors(['error' => $e->getMessage()]);
+            Log::error('Payment creation failed', ['error' => $e->getMessage(), 'trace' => $e->getTraceAsString()]);
+            return back()->withInput()->withErrors(['error' => '決済の作成に失敗しました']);
         }
     }
 
@@ -96,7 +98,8 @@ class PaymentController extends Controller
             return redirect()->route('payments.show', $payment)
                 ->with('success', '決済処理が完了しました。');
         } catch (\Exception $e) {
-            return back()->withErrors(['error' => $e->getMessage()]);
+            Log::error('Payment processing failed', ['payment_id' => $payment->id, 'error' => $e->getMessage(), 'trace' => $e->getTraceAsString()]);
+            return back()->withErrors(['error' => '決済処理に失敗しました']);
         }
     }
 
@@ -120,7 +123,8 @@ class PaymentController extends Controller
             return redirect()->route('payments.show', $payment)
                 ->with('success', '返金処理が完了しました。');
         } catch (\Exception $e) {
-            return back()->withErrors(['error' => $e->getMessage()]);
+            Log::error('Payment refund failed', ['payment_id' => $payment->id, 'error' => $e->getMessage(), 'trace' => $e->getTraceAsString()]);
+            return back()->withErrors(['error' => '返金処理に失敗しました']);
         }
     }
 
@@ -135,7 +139,8 @@ class PaymentController extends Controller
             return redirect()->route('payments.show', $payment)
                 ->with('success', '決済をキャンセルしました。');
         } catch (\Exception $e) {
-            return back()->withErrors(['error' => $e->getMessage()]);
+            Log::error('Payment cancellation failed', ['payment_id' => $payment->id, 'error' => $e->getMessage(), 'trace' => $e->getTraceAsString()]);
+            return back()->withErrors(['error' => '決済キャンセルに失敗しました']);
         }
     }
 


### PR DESCRIPTION
## Summary

- Replace `$request->all()` with `$validated` when calling `processPayment()` in the `process_now` branch of `store()`, ensuring the payment service receives only validated fields
- Replace raw `$e->getMessage()` in all four catch blocks (`store`, `process`, `refund`, `cancel`) with generic user messages; log full details via `Log::error()`

## Security impact

**Payment amount manipulation** — `processPayment($payment, $request->all())` passed the entire raw request to the payment service. When a real payment gateway integration reads `amount` or `token` from `$paymentData`, an attacker who can craft extra fields in the request body could supply a spoofed amount that differs from the validated and persisted amount, enabling underpayment.

**Exception disclosure** — all four catch blocks returned `$e->getMessage()` directly in form errors, which can expose database query text, service implementation details, or third-party gateway error strings to end users.

## Test plan

- [ ] Create a payment with `process_now=1` — gateway receives only validated fields, not arbitrary request data
- [ ] Trigger a payment error — browser shows generic message; details appear in Laravel logs only
- [ ] Trigger a refund error — same generic handling
- [ ] Trigger a cancel error — same generic handling

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_