### PR TITLE
fix: validate calendar/month and area filter inputs in EventController and TravelController

### DIFF
--- a/laravel_project/app/Http/Controllers/EventController.php
+++ b/laravel_project/app/Http/Controllers/EventController.php
@@ -179,8 +179,13 @@ class EventController extends Controller
      */
     public function calendar(Request $request)
     {
-        $region = $request->get('region', '東京');
-        $month = $request->get('month', date('Y-m'));
+        $validated = $request->validate([
+            'region' => 'nullable|string|max:100',
+            'month'  => 'nullable|date_format:Y-m',
+        ]);
+
+        $region = $validated['region'] ?? '東京';
+        $month  = $validated['month'] ?? date('Y-m');
 
         $startDate = $month . '-01';
         $endDate = date('Y-m-t', strtotime($startDate));

--- a/laravel_project/app/Http/Controllers/TravelController.php
+++ b/laravel_project/app/Http/Controllers/TravelController.php
@@ -348,8 +348,13 @@ class TravelController extends Controller
      */
     public function areas(Request $request): JsonResponse
     {
-        $parentId = $request->input('parent_id');
-        $level = $request->input('level');
+        $validated = $request->validate([
+            'parent_id' => 'nullable|integer|min:1',
+            'level'     => 'nullable|integer|min:1|max:5',
+        ]);
+
+        $parentId = $validated['parent_id'] ?? null;
+        $level    = $validated['level'] ?? null;
 
         $query = Area::query();
 


### PR DESCRIPTION
## Summary

- Add `$request->validate()` to `EventController::calendar()` — validate `region` (`string|max:100`) and `month` (`date_format:Y-m`) before using them to build date ranges passed to the event search service
- Add `$request->validate()` to `TravelController::areas()` — validate `parent_id` (`integer|min:1`) and `level` (`integer|min:1|max:5`) before forwarding them as Eloquent query conditions

## Security impact

**Unvalidated date construction** — `$month` was used directly in `$month . '-01'` and passed to `strtotime()`. An invalid value like `"; DROP TABLE events"` would produce a malformed date string; while PHP's `strtotime` degrades gracefully, the unvalidated value was forwarded to external APIs via `EventSearchService::searchEvents()`.

**Unvalidated query parameters** — `parent_id` and `level` were read directly from the request and passed as Eloquent `where()` conditions without type checking. An attacker could supply non-integer values that could cause unexpected query behavior.

## Test plan

- [ ] Request `/events/calendar?month=2025-07` — renders correctly
- [ ] Request `/events/calendar?month=invalid` — validation error returned
- [ ] Request `/events/calendar?region=大阪` — filters by region correctly
- [ ] Request `/api/travel/areas?level=2` — returns areas at level 2
- [ ] Request `/api/travel/areas?level=abc` — validation error returned
- [ ] Request `/api/travel/areas?level=99` — validation error (max 5)

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_