### PR TITLE
fix: return generic error message from ElectionController predict endpoint

### DIFF
--- a/laravel_project/app/Http/Controllers/ElectionController.php
+++ b/laravel_project/app/Http/Controllers/ElectionController.php
@@ -12,6 +12,7 @@ use App\Services\ElectionDataService;
 use App\Services\ElectionAnalysisService;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Log;
 use Carbon\Carbon;
 
 class ElectionController extends Controller
@@ -150,9 +151,14 @@ class ElectionController extends Controller
                 'data' => $result,
             ]);
         } catch (\Exception $e) {
+            Log::error('Election seat prediction failed', [
+                'election_id' => $election->id,
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
             return response()->json([
                 'status' => 'error',
-                'message' => '予測中にエラーが発生しました: ' . $e->getMessage(),
+                'message' => '議席予測に失敗しました',
             ], 500);
         }
     }


### PR DESCRIPTION
## Summary

- Add `Log::error()` in `ElectionController::predict()` catch block to record full exception details server-side
- Return a generic Japanese message `'議席予測に失敗しました'` instead of concatenating `$e->getMessage()` into the JSON response

## Security impact

**Exception disclosure** — the `predict()` endpoint's error response was `'予測中にエラーが発生しました: ' . $e->getMessage()`. The view at `elections/show.blade.php` renders this string directly in `alert('エラー: ' + data.message)`, surfacing PHP internal error text — SQL queries, stack context, service implementation details — in a browser dialog visible to end users.

## Test plan

- [ ] Trigger a prediction failure (e.g. no poll data) — browser alert shows generic `'議席予測に失敗しました'`
- [ ] Check Laravel log — full exception message and trace are present
- [ ] Successful prediction still returns 200 with prediction data

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_