### PR TITLE
fix: guard admin and system-managed fields in Review model against mass assignment

### DIFF
--- a/laravel_project/app/Http/Controllers/ReviewController.php
+++ b/laravel_project/app/Http/Controllers/ReviewController.php
@@ -116,8 +116,9 @@ class ReviewController extends Controller
             'amenities_rating' => $validated['amenities_rating'] ?? null,
             'title' => $validated['title'] ?? null,
             'comment' => $validated['comment'] ?? null,
-            'is_verified' => true, // 実際の予約からのレビューなので自動的に認証済み
         ]);
+        $review->is_verified = true;
+        $review->save();
 
         return redirect()->route('reviews.show', $review)
             ->with('success', 'レビューを投稿しました。ありがとうございます！');

--- a/laravel_project/app/Models/Review.php
+++ b/laravel_project/app/Models/Review.php
@@ -24,6 +24,9 @@ class Review extends Model
         'title',
         'comment',
         'photos',
+    ];
+
+    protected $guarded = [
         'is_verified',
         'is_published',
         'admin_response',
@@ -102,7 +105,8 @@ class Review extends Model
      */
     public function publish(): void
     {
-        $this->update(['is_published' => true]);
+        $this->is_published = true;
+        $this->save();
     }
 
     /**
@@ -110,7 +114,8 @@ class Review extends Model
      */
     public function unpublish(): void
     {
-        $this->update(['is_published' => false]);
+        $this->is_published = false;
+        $this->save();
     }
 
     /**
@@ -118,7 +123,8 @@ class Review extends Model
      */
     public function verify(): void
     {
-        $this->update(['is_verified' => true]);
+        $this->is_verified = true;
+        $this->save();
     }
 
     /**
@@ -126,10 +132,9 @@ class Review extends Model
      */
     public function addAdminResponse(string $response): void
     {
-        $this->update([
-            'admin_response' => $response,
-            'admin_responded_at' => now(),
-        ]);
+        $this->admin_response = $response;
+        $this->admin_responded_at = now();
+        $this->save();
     }
 
     /**


### PR DESCRIPTION
## Summary

- Move `is_verified`, `is_published`, `admin_response`, `admin_responded_at`, and `helpful_count` from `$fillable` to `$guarded` in the Review model
- Convert `publish()`, `unpublish()`, `verify()`, and `addAdminResponse()` model methods from `$this->update([...])` to direct property assignment + `$this->save()` since those fields are now guarded
- Fix `ReviewController::store()` to set `is_verified` via direct assignment after `Review::create()` instead of including it in the create array

## Security impact

**Admin field spoofing** — `is_verified`, `is_published`, `admin_response`, and `admin_responded_at` are admin-managed fields. Having them in `$fillable` means any code path calling `Review::create($request->all())` or `$review->update($request->all())` would let users publish their own reviews, self-verify them, or inject false admin responses.

**Counter manipulation** — `helpful_count` being fillable allows direct manipulation of the helpful vote counter without going through the `addHelpfulVote()` / `removeHelpfulVote()` methods that enforce the one-vote-per-customer constraint and maintain the `review_helpful_votes` pivot table.

## Test plan

- [ ] Submit a review via the form — `is_published` and `is_verified` start false/false
- [ ] POST `is_verified=1` in the review form — field is silently ignored
- [ ] Admin calls `$review->publish()` — `is_published` correctly becomes true
- [ ] Admin calls `$review->addAdminResponse(...)` — response saved; non-admins get 403
- [ ] `addHelpfulVote()` increments counter; second vote is rejected by pivot check

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_