### PR TITLE
fix: guard payment state fields against mass assignment

### DIFF
--- a/laravel_project/app/Models/Payment.php
+++ b/laravel_project/app/Models/Payment.php
@@ -14,16 +14,19 @@ class Payment extends Model
         'reservation_id',
         'amount',
         'payment_method',
-        'status',
-        'transaction_id',
         'payment_gateway',
         'payment_details',
+        'notes',
+    ];
+
+    protected $guarded = [
+        'status',
+        'transaction_id',
         'paid_at',
         'refunded_at',
         'refund_amount',
         'refund_reason',
         'failure_reason',
-        'notes',
     ];
 
     protected $casts = [
@@ -47,11 +50,10 @@ class Payment extends Model
      */
     public function markAsPaid(string $transactionId = null): void
     {
-        $this->update([
-            'status' => 'completed',
-            'paid_at' => now(),
-            'transaction_id' => $transactionId ?? $this->transaction_id,
-        ]);
+        $this->status = 'completed';
+        $this->paid_at = now();
+        $this->transaction_id = $transactionId ?? $this->transaction_id;
+        $this->save();
     }
 
     /**
@@ -59,10 +61,9 @@ class Payment extends Model
      */
     public function markAsFailed(string $reason): void
     {
-        $this->update([
-            'status' => 'failed',
-            'failure_reason' => $reason,
-        ]);
+        $this->status = 'failed';
+        $this->failure_reason = $reason;
+        $this->save();
     }
 
     /**
@@ -70,14 +71,11 @@ class Payment extends Model
      */
     public function refund(float $amount = null, string $reason = null): void
     {
-        $refundAmount = $amount ?? $this->amount;
-
-        $this->update([
-            'status' => 'refunded',
-            'refunded_at' => now(),
-            'refund_amount' => $refundAmount,
-            'refund_reason' => $reason,
-        ]);
+        $this->status = 'refunded';
+        $this->refunded_at = now();
+        $this->refund_amount = $amount ?? $this->amount;
+        $this->refund_reason = $reason;
+        $this->save();
     }
 
     /**

--- a/laravel_project/app/Services/PaymentService.php
+++ b/laravel_project/app/Services/PaymentService.php
@@ -35,7 +35,8 @@ class PaymentService
     {
         return DB::transaction(function () use ($payment, $paymentData) {
             // ステータスを処理中に変更
-            $payment->update(['status' => 'processing']);
+            $payment->status = 'processing';
+            $payment->save();
 
             try {
                 // 実際の決済ゲートウェイとの連携処理
@@ -46,16 +47,15 @@ class PaymentService
                     $payment->markAsPaid($result['transaction_id']);
 
                     // 予約のステータスも更新
-                    $payment->reservation->update([
-                        'payment_status' => 'paid',
-                    ]);
+                    $payment->reservation->payment_status = 'paid';
+                    $payment->reservation->save();
                 } else {
                     $payment->markAsFailed($result['error'] ?? 'Unknown error');
                 }
 
                 return $payment;
             } catch (Exception $e) {
-                $payment->markAsFailed($e->getMessage());
+                $payment->markAsFailed('決済ゲートウェイエラー');
                 throw $e;
             }
         });
@@ -120,9 +120,8 @@ class PaymentService
                 $payment->refund($refundAmount, $reason);
 
                 // 予約のステータスも更新
-                $payment->reservation->update([
-                    'payment_status' => 'refunded',
-                ]);
+                $payment->reservation->payment_status = 'refunded';
+                $payment->reservation->save();
             } else {
                 throw new Exception($result['error'] ?? 'Refund failed');
             }
@@ -166,7 +165,8 @@ class PaymentService
             throw new Exception('この決済はキャンセルできません。');
         }
 
-        $payment->update(['status' => 'cancelled']);
+        $payment->status = 'cancelled';
+        $payment->save();
 
         return $payment;
     }


### PR DESCRIPTION
## Summary

- Move `status`, `transaction_id`, `paid_at`, `refunded_at`, `refund_amount`, `refund_reason`, `failure_reason` from `$fillable` to `$guarded` in `Payment` model — these fields must only be set through controlled business logic, never via user-supplied request data
- Convert `markAsPaid()`, `markAsFailed()`, and `refund()` model methods from `$this->update([...])` to direct property assignment + `save()` so they continue to work despite the guard
- Fix `PaymentService::processPayment()`: `$payment->update(['status' => 'processing'])` → direct assignment (was silently no-oping with the guard in place)
- Fix `PaymentService::processPayment()` and `refundPayment()`: `$payment->reservation->update(['payment_status' => ...])` → direct assignment (Reservation's `payment_status` is also guarded per prior fix)
- Fix `PaymentService::cancelPayment()`: `$payment->update(['status' => 'cancelled'])` → direct assignment
- Replace `$payment->markAsFailed($e->getMessage())` with a generic string to prevent internal exception details from being stored in the payment record

## Security impact

Without this fix, a crafted POST to any payment endpoint that accepts these field names could overwrite `status`, `transaction_id`, or refund fields directly — bypassing the `markAsPaid`/`markAsFailed`/`refund` state machine entirely. The silent-failure behaviour of `update()` against guarded fields also masked several bugs in `PaymentService` where status transitions were never actually written to the database.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_