### PR TITLE
fix: add admin Gate and restrict election write routes to admin users

### DIFF
--- a/laravel_project/app/Models/User.php
+++ b/laravel_project/app/Models/User.php
@@ -43,6 +43,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'is_admin' => 'boolean',
         ];
     }
 }

--- a/laravel_project/app/Providers/AppServiceProvider.php
+++ b/laravel_project/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +20,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Gate::define('admin', fn ($user) => (bool) $user->is_admin);
     }
 }

--- a/laravel_project/database/migrations/2026_07_23_000001_add_is_admin_to_users_table.php
+++ b/laravel_project/database/migrations/2026_07_23_000001_add_is_admin_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_admin')->default(false)->after('email_verified_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_admin');
+        });
+    }
+};

--- a/laravel_project/routes/web.php
+++ b/laravel_project/routes/web.php
@@ -128,8 +128,8 @@ Route::get('/parties/{party}/trend', [ElectionController::class, 'partyTrend'])-
 Route::get('/election-districts', [ElectionController::class, 'districts'])->name('districts.index');
 Route::get('/elections/{election}/export', [ElectionController::class, 'exportReport'])->name('elections.export');
 
-// 書き込み系 (認証必須)
-Route::middleware('auth')->group(function () {
+// 書き込み系 (管理者のみ)
+Route::middleware(['auth', 'can:admin'])->group(function () {
     Route::post('/elections', [ElectionController::class, 'store'])->name('elections.store');
     Route::post('/elections/{election}/predict', [ElectionController::class, 'predict'])->name('elections.predict');
     Route::post('/elections/{election}/results', [ElectionController::class, 'storeResult'])->name('elections.results.store');


### PR DESCRIPTION
## Summary

- Add `is_admin` boolean column to the `users` table (migration, default `false`)
- Cast `is_admin` as boolean in `User` model
- Define `Gate::define('admin', fn ($user) => (bool) $user->is_admin)` in `AppServiceProvider::boot()`
- Change election write route group middleware from `'auth'` to `['auth', 'can:admin']`

## Security impact

Any authenticated user could previously POST to `/elections`, `/poll-data`, `/parties`, `/elections/{id}/results`, `/elections/{id}/predict`, and `/elections/import-csv` — there was no admin privilege check. This allowed any registered user to create elections, import CSV data, or trigger seat prediction runs.

The `can:admin` middleware now returns 403 for non-admin authenticated users, using the new `Gate::define('admin')` that checks the `is_admin` flag. Super-admins are the only users who can write election data.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_