### PR TITLE
fix: replace innerHTML with DOM API in elections accuracy results (XSS)

### DIFF
--- a/laravel_project/resources/views/elections/show.blade.php
+++ b/laravel_project/resources/views/elections/show.blade.php
@@ -316,22 +316,44 @@ document.getElementById('validateAccuracy')?.addEventListener('click', function(
     .then(response => response.json())
     .then(data => {
         if (data.status === 'success') {
-            let html = '<table class="table table-sm"><thead><tr>';
-            html += '<th>政党</th><th>予測</th><th>実績</th><th>誤差</th><th>範囲内</th></tr></thead><tbody>';
+            const container = document.getElementById('accuracyResults');
+            container.innerHTML = '';
 
+            const table = document.createElement('table');
+            table.className = 'table table-sm';
+            const thead = document.createElement('thead');
+            const headerRow = document.createElement('tr');
+            ['政党', '予測', '実績', '誤差', '範囲内'].forEach(text => {
+                const th = document.createElement('th');
+                th.textContent = text;
+                headerRow.appendChild(th);
+            });
+            thead.appendChild(headerRow);
+            table.appendChild(thead);
+
+            const tbody = document.createElement('tbody');
             for (const [party, result] of Object.entries(data.data.validation)) {
-                html += `<tr>
-                    <td>${party}</td>
-                    <td>${result.predicted}</td>
-                    <td>${result.actual}</td>
-                    <td>${result.error}</td>
-                    <td>${result.within_range ? '<span class="badge bg-success">Yes</span>' : '<span class="badge bg-danger">No</span>'}</td>
-                </tr>`;
+                const tr = document.createElement('tr');
+                [party, result.predicted, result.actual, result.error].forEach(val => {
+                    const td = document.createElement('td');
+                    td.textContent = val;
+                    tr.appendChild(td);
+                });
+                const tdBadge = document.createElement('td');
+                const badge = document.createElement('span');
+                badge.className = result.within_range ? 'badge bg-success' : 'badge bg-danger';
+                badge.textContent = result.within_range ? 'Yes' : 'No';
+                tdBadge.appendChild(badge);
+                tr.appendChild(tdBadge);
+                tbody.appendChild(tr);
             }
-            html += '</tbody></table>';
-            html += `<p class="text-muted">平均誤差: ${data.data.average_error}議席</p>`;
+            table.appendChild(tbody);
+            container.appendChild(table);
 
-            document.getElementById('accuracyResults').innerHTML = html;
+            const note = document.createElement('p');
+            note.className = 'text-muted';
+            note.textContent = `平均誤差: ${data.data.average_error}議席`;
+            container.appendChild(note);
         }
         this.disabled = false;
     });


### PR DESCRIPTION
## Summary

- Replace `innerHTML = html` (built from API response data) with `createElement`/`textContent` DOM API in the election accuracy validation results rendering

## Security impact

`elections/show.blade.php` built an HTML table by string-concatenating API response values (`party` keys, `result.predicted`, `result.actual`, `result.error`, `data.data.average_error`) into a template literal and assigning the entire string to `innerHTML`.

A compromised backend or a MITM response could inject `<script>` tags or event handlers via any of those fields. The fix uses `textContent` for all data values and constructs the badge spans from boolean logic only — no user-controlled string reaches the DOM parser.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_