### PR TITLE
fix: prevent server path and exception message disclosure in ElectionDataService

### DIFF
--- a/laravel_project/app/Services/ElectionDataService.php
+++ b/laravel_project/app/Services/ElectionDataService.php
@@ -71,7 +71,7 @@ class ElectionDataService
             DB::beginTransaction();
 
             if (!file_exists($filePath)) {
-                throw new \Exception("ファイルが見つかりません: {$filePath}");
+                throw new \Exception("指定されたファイルが見つかりません");
             }
 
             $handle = fopen($filePath, 'r');
@@ -108,7 +108,7 @@ class ElectionDataService
 
             return [
                 'status' => 'error',
-                'message' => $e->getMessage(),
+                'message' => 'CSVインポートに失敗しました',
                 'imported' => $imported,
             ];
         }
@@ -126,7 +126,7 @@ class ElectionDataService
             DB::beginTransaction();
 
             if (!file_exists($filePath)) {
-                throw new \Exception("ファイルが見つかりません: {$filePath}");
+                throw new \Exception("指定されたファイルが見つかりません");
             }
 
             $handle = fopen($filePath, 'r');
@@ -178,7 +178,7 @@ class ElectionDataService
 
             return [
                 'status' => 'error',
-                'message' => $e->getMessage(),
+                'message' => '世論調査データインポートに失敗しました',
                 'imported' => $imported,
             ];
         }


### PR DESCRIPTION
## Summary

- Replace path-containing exception messages with generic strings in `importElectionDataFromCsv()` and `importPollDataFromCsv()`
- Replace `'message' => $e->getMessage()` in both catch-block responses with fixed Japanese strings

## Security impact

Both CSV import methods threw `"ファイルが見つかりません: {$filePath}"` (file not found: /real/server/path) when the upload temp file was missing, and then returned `$e->getMessage()` directly in the JSON response — leaking the real server filesystem path to any caller.

The same catch blocks also returned the raw exception message for any other DB or parsing error, potentially exposing SQL, PHP class names, or stack details.

Error details are still written to the server log via `Log::error()` for operator visibility. Only the API response is sanitised.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_