### PR TITLE
fix: guard system-managed fields in Customer model against mass assignment

### DIFF
--- a/laravel_project/app/Models/Customer.php
+++ b/laravel_project/app/Models/Customer.php
@@ -17,12 +17,15 @@ class Customer extends Model
         'email',
         'phone',
         'address',
-        'last_stay_date',
-        'total_stays',
-        'total_spent',
         'privacy_consent',
         'privacy_consent_date',
         'marketing_consent',
+    ];
+
+    protected $guarded = [
+        'total_stays',
+        'total_spent',
+        'last_stay_date',
         'deletion_requested',
         'deletion_requested_at',
     ];


### PR DESCRIPTION
## Summary

- Move `total_stays`, `total_spent`, `last_stay_date`, `deletion_requested`, `deletion_requested_at` from `$fillable` to `$guarded` in `Customer` model

## Security impact

These five fields are system-managed computed values:
- `total_stays` / `total_spent` / `last_stay_date` — updated by `CheckInOutService::updateStayHistory()` after a real checkout
- `deletion_requested` / `deletion_requested_at` — set by `Customer::requestDeletion()` as part of a GDPR workflow

With these fields in `$fillable`, a crafted PATCH/PUT to any customer endpoint that calls `$customer->update($request->validated())` — or any future code path that mass-assigns request data — could allow a user to:
- Inflate their own `total_stays` / `total_spent` (loyalty tier fraud)
- Set `deletion_requested = false` to cancel their own pending GDPR deletion request

The model's `updateStayHistory()` and `requestDeletion()` methods already use direct property assignment + `save()`, so moving to `$guarded` has no impact on the business logic.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_