### PR TITLE
fix: guard reservation state fields and whitelist updateReservation inputs

### DIFF
--- a/laravel_project/app/Models/Reservation.php
+++ b/laravel_project/app/Models/Reservation.php
@@ -35,18 +35,21 @@ class Reservation extends Model
         'number_of_guests',
         'check_in_date',
         'check_out_date',
-        'status',
-        'payment_status',
-        'actual_check_in_time',
-        'actual_check_out_time',
         'total_amount',
         'applied_discounts',
         'price_breakdown',
-        'cancelled_at',
         'cancellation_reason',
         'notes',
         'created_by_user_id',
         'updated_by_user_id',
+    ];
+
+    protected $guarded = [
+        'status',
+        'payment_status',
+        'actual_check_in_time',
+        'actual_check_out_time',
+        'cancelled_at',
     ];
 
     protected $casts = [

--- a/laravel_project/app/Services/ReservationService.php
+++ b/laravel_project/app/Services/ReservationService.php
@@ -55,13 +55,14 @@ class ReservationService
                 'number_of_guests' => $numberOfGuests,
                 'check_in_date' => $checkIn,
                 'check_out_date' => $checkOut,
-                'status' => Reservation::STATUS_PROVISIONAL,
                 'total_amount' => $pricing['total_amount'],
                 'applied_discounts' => $pricing['applied_discounts'],
                 'price_breakdown' => $pricing['breakdown'],
                 'notes' => $data['notes'] ?? null,
                 'created_by_user_id' => $data['user_id'] ?? null,
             ]);
+            $reservation->status = Reservation::STATUS_PROVISIONAL;
+            $reservation->save();
 
             // 在庫を予約
             $reserved = $this->inventoryService->reserveInventory(
@@ -203,7 +204,12 @@ class ReservationService
                 $data['price_breakdown'] = $pricing['breakdown'];
             }
 
-            $reservation->update($data);
+            $allowedFields = [
+                'number_of_guests', 'check_in_date', 'check_out_date',
+                'total_amount', 'applied_discounts', 'price_breakdown',
+                'cancellation_reason', 'notes', 'updated_by_user_id',
+            ];
+            $reservation->update(array_intersect_key($data, array_flip($allowedFields)));
 
             if (isset($data['user_id'])) {
                 $reservation->updated_by_user_id = $data['user_id'];


### PR DESCRIPTION
## Summary

- Move `status`, `payment_status`, `actual_check_in_time`, `actual_check_out_time`, `cancelled_at` from `$fillable` to `$guarded` in `Reservation` model
- Fix `ReservationService::createReservation()` to set initial `status` via direct property assignment after `create()`
- Add explicit field whitelist in `ReservationService::updateReservation()` to prevent raw `$data` from reaching guarded fields

## Security impact

**State machine bypass**: `status` was mass-assignable, so any endpoint that called `$reservation->update($request->validated())` without explicitly excluding it could allow a user to transition a reservation to any status — `checked_out`, `cancelled`, `no_show` — bypassing the `canTransitionTo()` guard and the audit trail written by `changeStatus()`.

**payment_status manipulation**: Similarly, `payment_status` being fillable allowed forging a `paid` or `refunded` status without going through `PaymentService`.

**cancelled_at / actual_check_in_time spoofing**: Timestamps that should only be set by the check-in/out and cancellation workflows could be overwritten with arbitrary values.

The `changeStatus()`, `checkIn()`, `checkOut()`, and `cancelReservation()` internal methods already use direct property assignment + `save()` — they continue to work correctly after this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_