### PR TITLE
fix: guard stock_quantity in Product model and fix inventory info disclosure

### DIFF
--- a/laravel_project/app/Http/Controllers/ProductController.php
+++ b/laravel_project/app/Http/Controllers/ProductController.php
@@ -74,7 +74,11 @@ class ProductController extends Controller
             'reorder_point' => ['required', 'integer', 'min:0'],
         ]);
 
-        Product::create($validated);
+        $initialStock = $validated['stock_quantity'];
+        unset($validated['stock_quantity']);
+        $product = Product::create($validated);
+        $product->stock_quantity = $initialStock;
+        $product->save();
 
         return redirect()
             ->route('products.index')

--- a/laravel_project/app/Models/Product.php
+++ b/laravel_project/app/Models/Product.php
@@ -17,9 +17,12 @@ class Product extends Model
         'sku',
         'name',
         'description',
-        'stock_quantity',
         'reorder_point',
         'warehouse_id',
+    ];
+
+    protected $guarded = [
+        'stock_quantity',
     ];
 
     protected $casts = [

--- a/laravel_project/app/Services/StockService.php
+++ b/laravel_project/app/Services/StockService.php
@@ -78,9 +78,7 @@ class StockService
 
         // WHY: 在庫がマイナスになることを防ぐ（ビジネスルール）
         if ($product->stock_quantity < $quantity) {
-            throw new InvalidArgumentException(
-                "在庫不足: 現在庫{$product->stock_quantity}個に対して{$quantity}個の出庫はできません"
-            );
+            throw new InvalidArgumentException('在庫が不足しています。現在の在庫数を確認してください。');
         }
 
         return DB::transaction(function () use ($product, $quantity, $reason, $createdBy) {
@@ -139,7 +137,8 @@ class StockService
             ]);
 
             // 2. 商品の在庫数を実地棚卸の値に更新
-            $product->update(['stock_quantity' => $actualQuantity]);
+            $product->stock_quantity = $actualQuantity;
+            $product->save();
 
             // 3. 監査ログ（棚卸差異は重要なので別途記録）
             Log::warning('Stock ADJUST', [


### PR DESCRIPTION
## Summary

- Move `stock_quantity` from `$fillable` to `$guarded` in `Product` model
- Fix `ProductController::store()` to set initial stock via direct property assignment after `create()`
- Fix `StockService::adjust()` to use direct property assignment + `save()` instead of `update([...])` which would silently fail against the guard
- Replace the information-leaking exception message in `StockService::stockOut()` with a generic string

## Security impact

**Mass-assignment bypass**: `stock_quantity` in `$fillable` allowed any code path that called `$product->update($request->all())` or similar to directly set stock levels — bypassing the `StockService` audit trail that logs every stock change with a reason and a user ID.

**Information disclosure**: `stockOut()` threw `"在庫不足: 現在庫{$product->stock_quantity}個に対して{$quantity}個の出庫はできません"`, and `StockTransactionController` returned this message verbatim as a form validation error. This exposed exact current inventory levels to the user making the stock-out request.

`stockIn()` and `stockOut()` use `increment()`/`decrement()` which bypass `$guarded` and continue to work correctly. Only `adjust()` used `update([...])` and needed the direct-assignment fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_