### PR TITLE
fix: guard admin/system fields in Review model against mass assignment

### DIFF
--- a/laravel_project/app/Http/Controllers/ReviewController.php
+++ b/laravel_project/app/Http/Controllers/ReviewController.php
@@ -116,8 +116,10 @@ class ReviewController extends Controller
             'amenities_rating' => $validated['amenities_rating'] ?? null,
             'title' => $validated['title'] ?? null,
             'comment' => $validated['comment'] ?? null,
-            'is_verified' => true, // 実際の予約からのレビューなので自動的に認証済み
         ]);
+        // 実際の予約からのレビューなので自動的に認証済みにする
+        $review->is_verified = true;
+        $review->save();
 
         return redirect()->route('reviews.show', $review)
             ->with('success', 'レビューを投稿しました。ありがとうございます！');
@@ -205,6 +207,8 @@ class ReviewController extends Controller
      */
     public function addAdminResponse(Review $review, Request $request)
     {
+        abort_unless(auth()->user()?->is_admin, 403, '管理者権限が必要です。');
+
         $validated = $request->validate([
             'admin_response' => 'required|string|max:1000',
         ]);

--- a/laravel_project/app/Models/Review.php
+++ b/laravel_project/app/Models/Review.php
@@ -24,6 +24,9 @@ class Review extends Model
         'title',
         'comment',
         'photos',
+    ];
+
+    protected $guarded = [
         'is_verified',
         'is_published',
         'admin_response',
@@ -102,7 +105,8 @@ class Review extends Model
      */
     public function publish(): void
     {
-        $this->update(['is_published' => true]);
+        $this->is_published = true;
+        $this->save();
     }
 
     /**
@@ -110,7 +114,8 @@ class Review extends Model
      */
     public function unpublish(): void
     {
-        $this->update(['is_published' => false]);
+        $this->is_published = false;
+        $this->save();
     }
 
     /**
@@ -118,7 +123,8 @@ class Review extends Model
      */
     public function verify(): void
     {
-        $this->update(['is_verified' => true]);
+        $this->is_verified = true;
+        $this->save();
     }
 
     /**
@@ -126,10 +132,9 @@ class Review extends Model
      */
     public function addAdminResponse(string $response): void
     {
-        $this->update([
-            'admin_response' => $response,
-            'admin_responded_at' => now(),
-        ]);
+        $this->admin_response = $response;
+        $this->admin_responded_at = now();
+        $this->save();
     }
 
     /**


### PR DESCRIPTION
## Summary

- Move `is_verified`, `is_published`, `admin_response`, `admin_responded_at`, `helpful_count` from `$fillable` to `$guarded` in `Review` model
- Convert `publish()`, `unpublish()`, `verify()`, `addAdminResponse()` model methods to use direct property assignment + `save()`
- Fix `ReviewController::store()` to set `is_verified` via direct assignment after `create()` rather than passing it into `create()`
- Add admin privilege check to `ReviewController::addAdminResponse()`

## Security impact

With these fields in `$fillable`, a crafted POST to the review store or update endpoint could:
- Set `is_verified = true` on self-submitted reviews (bypassing the "verified stay" badge)
- Set `is_published = true` to immediately publish a review (bypassing moderation)
- Inject arbitrary `admin_response` text attributed to the admin
- Inflate `helpful_count` without going through the vote workflow

The `addAdminResponse()` endpoint had no admin check — any authenticated user could POST a fake admin reply to any review.

---
_Generated by [Claude Code](https://claude.ai/code/session_017vuHqwyzTL2WJen1SZrW4x)_